### PR TITLE
Reboot map with support for House and Senate

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -1,10 +1,12 @@
 import { Component, Fragment } from "react";
-import Head from "next/head";
 import L from "leaflet";
-// import Papa from "papaparse";
 import "leaflet/dist/leaflet.css";
-import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
+import "leaflet-providers";
+import "leaflet-search";
+import "leaflet-search/dist/leaflet-search.min.css";
 import "leaflet-defaulticon-compatibility";
+import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
+// import Papa from "papaparse";
 
 /**
  * Based on https://github.com/bhrutledge/ma-legislature/blob/main/index.html
@@ -143,19 +145,8 @@ class Map extends Component {
 
   render() {
     return (
-      // TODO: Replace the CSS and JS with imports
       <Fragment>
-        <Head>
-          <link
-            rel="stylesheet"
-            href="https://unpkg.com/leaflet-search@2.9.9/dist/leaflet-search.min.css"
-          />
-        </Head>
         <div id="map" style={{ width: "100%", height: "50vh"}}></div>
-        <Head>
-          <script src="https://unpkg.com/leaflet-providers@1.11.0/leaflet-providers.js"></script>
-          <script src="https://unpkg.com/leaflet-search@2.9.9/dist/leaflet-search.min.js"></script>
-        </Head>
       </Fragment>
     );
   }

--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -1,156 +1,149 @@
 import { Component, Fragment } from "react";
 import Head from "next/head";
 import L from "leaflet";
-import Papa from "papaparse";
+// import Papa from "papaparse";
 import "leaflet/dist/leaflet.css";
 import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
 import "leaflet-defaulticon-compatibility";
 
-const districtStyle = (rep) => ({
-  className: `district district--${rep.commitments ? "committed" : "join"}`,
-});
-
-const callToAction = (rep) => `
-  <a class="map-link"
-    href="https://actonmass.org/the-campaign/?your_state_representative=${
-      rep.first_name
-    } ${rep.last_name}#join-your-district-team"
-    target="_parent"
-  >
-    <strong>Join ${rep.commitments ? "the Campaign" : "District Team"}</strong>
-  </a>
-`;
-
-const repCommitments = (rep) =>
-  rep.commitments
-    ? `
-		<p>
-      <table>
-        <tr>
-          <th colspan="2">
-            <strong>Committed to vote for:</strong>
-          </th>
-        </tr>
-        <tr>
-          <td class="commitment">${rep.committee_votes ? "✓" : ""}</td>
-          <td>Committee votes made public</td>
-        </tr>
-        <tr>
-          <td class="commitment">${rep.public_bills ? "✓" : ""}</td>
-          <td>Bills made public for 72 hours</td>
-        </tr>
-        <tr>
-          <td class="commitment">${rep.roll_call ? "✓" : ""}</td>
-          <td>Lower threshold for public roll call</td>
-        </tr>
-      </table>
-    </p>
-  `
-    : "";
-
-const districtPopup = (rep) => `
-	<p>
-		<strong>${rep.first_name} ${rep.last_name}</strong>
-		${rep.url ? `(<a href="${rep.url}">contact</a>)` : ""}
-		<br />${rep.party ? `${rep.party},` : ""}
-		${rep.district}
-		${rep.elect ? "(Elect)" : ""}
-	</p>
-	${repCommitments(rep)}
-	${callToAction(rep)}
-`;
-
-const onPopup = (e) => {
-  const active = e.type === "popupopen";
-  e.target.getElement().classList.toggle("district--active", active);
-};
-
-const districtLegend = () => `
-		<div class="legend__item legend__item--committed">Committed to Vote</div>
-    <div class="legend__item legend__item--join">Join District Team</div>
-`;
-
-const style = {
-  width: "100%",
-  height: "50vh",
-};
-
+/**
+ * Based on https://github.com/bhrutledge/ma-legislature/blob/main/index.html
+ */
 class Map extends Component {
   componentDidMount() {
+    /* Load the legislative district boundaries and rep data */
+
     Promise.all([
-      fetch(
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ4l7bRcBIgwsEPGM_s9zF9csIeTgE2No_4tA6MuDCBUbfmWY_e9mAfzPpCJTsIK_hUzOyJ8CmdGMsX/pub?gid=641305740&single=true&output=csv"
-      )
-        .then((response) => response.text())
-        .then((csv) => {
-          const parsed = Papa.parse(csv, { header: true, dynamicTyping: true });
-          return Promise.resolve(parsed.data);
-        }),
-      fetch(
-        "https://raw.githubusercontent.com/bhrutledge/ma-legislature/main/dist/ma_house.geojson"
-      ).then((response) => response.json()),
-    ]).then(([supporters, houseFeatures]) => {
-      const supportersByDistrict = supporters.reduce((acc, cur) => {
-        acc[cur.district] = cur;
-        return acc;
-      }, {});
+      /* The GeoJSON contains basic contact information for each rep */
+      fetch('https://bhrutledge.com/ma-legislature/dist/ma_house.geojson').then((response) => response.json()),
+      fetch('https://bhrutledge.com/ma-legislature/dist/ma_senate.geojson').then((response) => response.json()),
+      /**
+       * To add additional data about each rep/district, uncomment this `fetch`
+       * and set the URL to a JSON data source with a `district` field.
+       *
+       * For a CSV, use https://www.papaparse.com/; see an example at:
+       * https://github.com/actonmass/campaign-map/blob/main/index.html
+       */
+      // fetch('https://example.com/rep_data.json').then((response) => response.json()),
+    ])
+      .then(([houseFeatures, senateFeatures, repData = []]) => {
+        /* Build a rep info object, e.g. `rep.first_name`, `rep.extra_data` */
 
-      function repProperties(feature) {
-        const supporter = supportersByDistrict[feature.properties.district];
-        return supporter;
-      }
+        const repDataByDistrict = repData.reduce((acc, cur) => {
+          acc[cur.district] = cur;
+          return acc;
+        }, {});
 
-      const houseLayer = L.geoJson(houseFeatures, {
-        style: (feature) => districtStyle(repProperties(feature)),
-        onEachFeature: (feature, layer) => {
-          const rep = repProperties(feature);
-          layer.bindPopup(districtPopup(rep));
-          layer.on("popupopen", onPopup);
-          layer.on("popupclose", onPopup);
-          feature.properties.index = `${rep.first_name} ${rep.last_name} - ${rep.district}`;
-        },
+        const repProperties = (feature) => {
+          const data = repDataByDistrict[feature.properties.district] || {};
+          return { ...feature.properties, ...data };
+        };
+
+        /* Templates for map elements */
+
+        const districtLegend = () => /* html */`
+          <div class="legend__item legend__item--Democrat">
+            Democrat
+          </div>
+          <div class="legend__item legend__item--Republican">
+            Republican
+          </div>
+          <div class="legend__item legend__item">
+            Other
+          </div>
+        `;
+
+        const districtStyle = (rep) => ({
+          className: `district district--${rep.party}`,
+        });
+
+        const districtPopup = (rep) => `
+          <p>
+            <strong>${rep.first_name} ${rep.last_name}</strong>
+            ${rep.party ? `<br />${rep.party}` : ''}
+            <br />${rep.district}
+            ${rep.url ? `<br /><a href="${rep.url}">Contact</a>` : ''}
+          </p>
+        `;
+
+        const onPopup = (e) => {
+          const active = e.type === 'popupopen';
+          e.target.getElement().classList.toggle('district--active', active);
+        };
+
+        /* Build the district layers */
+
+        const districtLayer = (features) => L.geoJson(features, {
+          style: (feature) => districtStyle(repProperties(feature)),
+          onEachFeature: (feature, layer) => {
+            const rep = repProperties(feature);
+
+            layer.bindPopup(districtPopup(rep));
+            layer.on('popupopen', onPopup);
+            layer.on('popupclose', onPopup);
+
+            // Enable searching by name or district; inspired by:
+            // https://github.com/stefanocudini/leaflet-search/issues/52#issuecomment-266168224
+            // eslint-disable-next-line no-param-reassign
+            feature.properties.index = `${rep.first_name} ${rep.last_name} - ${rep.district}`;
+          },
+        });
+
+        const districtSearch = (layer) => new L.Control.Search({
+          layer,
+          propertyName: 'index',
+          initial: false,
+          marker: false,
+          textPlaceholder: 'Search legislators and districts',
+          moveToLocation(latlng, title, map) {
+            map.fitBounds(latlng.layer.getBounds());
+            latlng.layer.openPopup();
+          },
+        });
+
+        const layers = {
+          House: districtLayer(houseFeatures),
+          Senate: districtLayer(senateFeatures),
+        };
+
+        const searchControls = {
+          House: districtSearch(layers.House),
+          Senate: districtSearch(layers.Senate),
+        };
+
+        /* Build the map */
+
+        const map = L.map('map').addLayer(L.tileLayer.provider('CartoDB.Positron'));
+
+        Object.keys(layers).forEach((chamber) => {
+          layers[chamber]
+            .on('add', () => searchControls[chamber].addTo(map))
+            .on('remove', () => searchControls[chamber].remove());
+        });
+
+        map.addLayer(layers.House)
+          .fitBounds(layers.House.getBounds())
+          // Avoid accidental excessive zoom out
+          .setMinZoom(map.getZoom());
+
+        const layerControl = L.control.layers(layers, {}, {
+          collapsed: false,
+        });
+        layerControl.addTo(map);
+
+        const legendControl = L.control({ position: 'topright' });
+        legendControl.onAdd = () => {
+          const div = L.DomUtil.create('div', 'legend');
+          div.innerHTML = districtLegend();
+          return div;
+        };
+        legendControl.addTo(map);
       });
-
-      const searchControl = new L.Control.Search({
-        layer: houseLayer,
-        propertyName: "index",
-        initial: false,
-        marker: false,
-        textPlaceholder: "Search reps and districts",
-        moveToLocation(latlng, title, map) {
-          map.fitBounds(latlng.layer.getBounds());
-          latlng.layer.openPopup();
-        },
-      });
-
-      const legendControl = L.control({ position: "topright" });
-      legendControl.onAdd = () => {
-        const div = L.DomUtil.create("div", "legend");
-        div.innerHTML = districtLegend();
-        return div;
-      };
-      const baseLayer = L.tileLayer(
-        "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-        {
-          attribution:
-            '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-        }
-      );
-
-      this.map = L.map("map")
-        .addLayer(baseLayer)
-        .addLayer(houseLayer)
-        .addControl(searchControl)
-        .addControl(legendControl)
-        .fitBounds(houseLayer.getBounds());
-
-      // Avoid accidental excessive zoom out
-      this.map.setMinZoom(this.map.getZoom());
-    });
   }
 
   render() {
     return (
+      // TODO: Replace the CSS and JS with imports
       <Fragment>
         <Head>
           <link
@@ -158,8 +151,9 @@ class Map extends Component {
             href="https://unpkg.com/leaflet-search@2.9.9/dist/leaflet-search.min.css"
           />
         </Head>
-        <div id="map" style={style}></div>
+        <div id="map" style={{ width: "100%", height: "50vh"}}></div>
         <Head>
+          <script src="https://unpkg.com/leaflet-providers@1.11.0/leaflet-providers.js"></script>
           <script src="https://unpkg.com/leaflet-search@2.9.9/dist/leaflet-search.min.js"></script>
         </Head>
       </Fragment>

--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -146,7 +146,9 @@ class Map extends Component {
   render() {
     return (
       <Fragment>
-        <div id="map" style={{ width: "100%", height: "50vh"}}></div>
+        <div id="map-wrapper">
+          <div id="map"></div>
+        </div>
       </Fragment>
     );
   }

--- a/styles/Map.css
+++ b/styles/Map.css
@@ -7,6 +7,24 @@
     --color--Republican--active: rgba(255, 0, 0, 0.9);
 }
 
+/* Give the map a responsive 64% aspect ratio (same as Massachusetts) */
+/* https://css-tricks.com/aspect-ratio-boxes/ */
+
+#map-wrapper {
+    position: relative;
+    overflow: hidden;
+    padding-top: 64%;
+}
+
+#map {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 #map:not(.leaflet-container)::after {
     content: '…loading map…';
     display: block;

--- a/styles/Map.css
+++ b/styles/Map.css
@@ -1,109 +1,95 @@
 :root {
-	--join-color: rgba(0, 0, 0, 0.2);
-	--join-color--active: rgba(0, 0, 0, 0.4);
-	--committed-color: rgba(90, 186, 161, 0.6);
-	--committed-color--active: rgba(90, 186, 161, 0.9);
-}
-
-#map {
-	height: 100%;
-	width: 100%;
+    --color--district: rgba(0, 0, 0, 0.2);
+    --color--district--active: rgba(0, 0, 0, 0.4);
+    --color--Democrat: rgba(0, 0, 255, 0.5);
+    --color--Democrat--active: rgba(0, 0, 255, 0.9);
+    --color--Republican: rgba(255, 0, 0, 0.5);
+    --color--Republican--active: rgba(255, 0, 0, 0.9);
 }
 
 #map:not(.leaflet-container)::after {
-	content: '…loading map…';
-	display: block;
-	padding: 1rem;
-	text-align: center;
-	/* Matching .leaflet-container */
-	font: oblique 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
-}
-
-a.map-link {
-	color: #00529A !important;
+    content: '…loading map…';
+    display: block;
+    padding: 1rem;
+    text-align: center;
+    /* Matching .leaflet-container */
+    font: oblique 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
 }
 
 .legend {
-	background: white;
-	border: 2px solid rgba(0, 0, 0, 0.2);
-	border-radius: 4px;
-	padding: 0 0.5rem;
+    background: white;
+    border: 2px solid rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    padding: 0 0.5rem;
 }
 
 .legend__item {
-	display: flex;
-	align-items: center;
-	margin: 0.5rem 0;
+    display: flex;
+    align-items: center;
+    margin: 0.5rem 0;
 }
 
 .legend__item::before {
-	background: var(--join-color);
-	border-radius: 2px;
-	content: '';
-	display: block;
-	margin-right: 0.5rem;
-	height: 1rem;
-	width: 1rem;
+    background: var(--color--district);
+    border-radius: 2px;
+    content: '';
+    display: block;
+    margin-right: 0.5rem;
+    height: 1rem;
+    width: 1rem;
 }
 
-.legend__item--committed::before {
-	background: var(--committed-color);
+.legend__item--Democrat::before {
+    background: var(--color--Democrat);
+}
+
+.legend__item--Republican::before {
+    background: var(--color--Republican);
 }
 
 .district {
-	fill: var(--join-color);
-	fill-opacity: 1;
-	stroke: var(--join-color);
-	stroke-width: 1;
+    fill: var(--color--district);
+    fill-opacity: 1;
+    stroke: var(--color--district);
+    stroke-width: 1;
 }
 
 .district:hover {
-	stroke-width: 4;
+    stroke-width: 4;
 }
 
 .district--active {
-	fill: var(--join-color--active);
+    fill: var(--color--district--active);
 }
 
-.district--committed {
-	fill: var(--committed-color);
+.district--Democrat {
+    fill: var(--color--Democrat);
 }
 
-.district--committed.district--active {
-	fill: var(--committed-color--active);
+.district--Democrat.district--active {
+    fill: var(--color--Democrat--active);
+}
+
+.district--Republican {
+    fill: var(--color--Republican);
+}
+
+.district--Republican.district--active {
+    fill: var(--color--Republican--active);
 }
 
 .leaflet-control-search .search-input {
-	outline: none;
-	width: 15rem;
+    outline: none;
+    width: 15rem;
 }
 
 .leaflet-control-search .search-tooltip {
-	margin: 2px 0 0;
-	width: 100%;
-	border-radius: 4px;
+    margin: 2px 0 0;
+    width: 100%;
+    border-radius: 4px;
 }
 
 .leaflet-control-search .search-tip {
-	margin: 0;
-	border-radius: 0;
-}
-
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-	font: inherit;
-	width: 100%;
-}
-
-th,
-td {
-	text-align: left;
-	vertical-align: baseline;
-	white-space: nowrap;
-}
-
-.commitment {
-	color: var(--committed-color--active);
-	padding-right: 0.25rem;
+    margin: 0;
+    border-radius: 0;
 }


### PR DESCRIPTION
Closes #21, supersedes #25

Changes:

- Replace code ported from https://github.com/actonmass/campaign-map/ with code copied from https://github.com/bhrutledge/ma-legislature/
- Use `import` for CSS and JS instead of `<link>` and `<style>`

https://user-images.githubusercontent.com/1326704/106401098-46705580-63f0-11eb-8197-c7d4537d91ab.mp4

