### PR TITLE
Color districts using EDR data

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -6,7 +6,7 @@ import "leaflet-search";
 import "leaflet-search/dist/leaflet-search.min.css";
 import "leaflet-defaulticon-compatibility";
 import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
-// import Papa from "papaparse";
+import Papa from "papaparse";
 
 /**
  * Based on https://github.com/bhrutledge/ma-legislature/blob/main/index.html
@@ -19,52 +19,64 @@ class Map extends Component {
       /* The GeoJSON contains basic contact information for each rep */
       fetch('https://bhrutledge.com/ma-legislature/dist/ma_house.geojson').then((response) => response.json()),
       fetch('https://bhrutledge.com/ma-legislature/dist/ma_senate.geojson').then((response) => response.json()),
-      /**
-       * To add additional data about each rep/district, uncomment this `fetch`
-       * and set the URL to a JSON data source with a `district` field.
-       *
-       * For a CSV, use https://www.papaparse.com/; see an example at:
-       * https://github.com/actonmass/campaign-map/blob/main/index.html
-       */
-      // fetch('https://example.com/rep_data.json').then((response) => response.json()),
+      /* URL via EDR Data > File > Publish to the web > Link > Sheet1 > CSV > Publish */
+      fetch('https://docs.google.com/spreadsheets/d/e/2PACX-1vRe608XwzuZhMlOP6GKU5ny1Kz-rlGFUhwZmhZwAZGbbAWOHlP01-S3MFD9dlerPEqjynsUbeQmBl-E/pub?gid=0&single=true&output=csv')
+        .then((response) => response.text())
+        .then((csv) => {
+          const parsed = Papa.parse(csv, { header: true, dynamicTyping: true });
+          return Promise.resolve(parsed.data);
+        }),
     ])
       .then(([houseFeatures, senateFeatures, repData = []]) => {
         /* Build a rep info object, e.g. `rep.first_name`, `rep.extra_data` */
 
-        const repDataByDistrict = repData.reduce((acc, cur) => {
-          acc[cur.district] = cur;
+        const repDataByURL = repData.reduce((acc, cur) => {
+          acc[cur.url] = cur;
           return acc;
         }, {});
 
+        console.log(repDataByURL);
+
         const repProperties = (feature) => {
-          const data = repDataByDistrict[feature.properties.district] || {};
+          const data = repDataByURL[feature.properties.url] || {};
           return { ...feature.properties, ...data };
         };
 
         /* Templates for map elements */
 
         const districtLegend = () => /* html */`
-          <div class="legend__item legend__item--Democrat">
-            Democrat
+          <strong>Grade of support for bill</strong>
+          <div class="legend__item legend__item--grade-1">
+            1: Committed to vote
           </div>
-          <div class="legend__item legend__item--Republican">
-            Republican
+          <div class="legend__item legend__item--grade-2">
+            2: Substantial past advocacy
           </div>
-          <div class="legend__item legend__item">
-            Other
+          <div class="legend__item legend__item--grade-3">
+            3: Some past advocacy
+          </div>
+          <div class="legend__item legend__item--grade-4">
+            4: No support
           </div>
         `;
 
         const districtStyle = (rep) => ({
-          className: `district district--${rep.party}`,
+          className: `district district--${rep.party} district--grade-${rep.grade}`,
         });
 
-        const districtPopup = (rep) => `
+        const districtPopup = (rep) => /* html */`
           <p>
             <strong>${rep.first_name} ${rep.last_name}</strong>
             ${rep.party ? `<br />${rep.party}` : ''}
             <br />${rep.district}
             ${rep.url ? `<br /><a href="${rep.url}">Contact</a>` : ''}
+          </p>
+          <p>
+            <!-- TODO: Show textual description of grade? -->
+            Grade: ${rep.grade}
+            <!-- TODO: Display individual bills, but keep it generic.
+            This probably means using a regex to match keys like "191/H685".
+            -->
           </p>
         `;
 
@@ -133,7 +145,7 @@ class Map extends Component {
         });
         layerControl.addTo(map);
 
-        const legendControl = L.control({ position: 'topright' });
+        const legendControl = L.control({ position: 'bottomleft' });
         legendControl.onAdd = () => {
           const div = L.DomUtil.create('div', 'legend');
           div.innerHTML = districtLegend();

--- a/styles/Map.css
+++ b/styles/Map.css
@@ -1,10 +1,13 @@
 :root {
     --color--district: rgba(0, 0, 0, 0.2);
     --color--district--active: rgba(0, 0, 0, 0.4);
-    --color--Democrat: rgba(0, 0, 255, 0.5);
-    --color--Democrat--active: rgba(0, 0, 255, 0.9);
-    --color--Republican: rgba(255, 0, 0, 0.5);
-    --color--Republican--active: rgba(255, 0, 0, 0.9);
+    /* https://colorbrewer2.org/#type=sequential&scheme=Greens&n=5 */
+    --color--grade-1: rgba(0, 109, 44, 0.5);
+    --color--grade-1--active: rgba(0, 109, 44, 0.9);
+    --color--grade-2: rgba(49, 163, 84, 0.5);
+    --color--grade-2--active: rgba(49, 163, 84, 0.9);
+    --color--grade-3: rgba(116, 196, 118, 0.5);
+    --color--grade-3--active: rgba(116, 196, 118, 0.9);
 }
 
 /* Give the map a responsive 64% aspect ratio (same as Massachusetts) */
@@ -57,12 +60,16 @@
     width: 1rem;
 }
 
-.legend__item--Democrat::before {
-    background: var(--color--Democrat);
+.legend__item--grade-1::before {
+    background: var(--color--grade-1);
 }
 
-.legend__item--Republican::before {
-    background: var(--color--Republican);
+.legend__item--grade-2::before {
+    background: var(--color--grade-2);
+}
+
+.legend__item--grade-3::before {
+    background: var(--color--grade-3);
 }
 
 .district {
@@ -80,20 +87,28 @@
     fill: var(--color--district--active);
 }
 
-.district--Democrat {
-    fill: var(--color--Democrat);
+.district--grade-1 {
+    fill: var(--color--grade-1);
 }
 
-.district--Democrat.district--active {
-    fill: var(--color--Democrat--active);
+.district--grade-1.district--active {
+    fill: var(--color--grade-1--active);
 }
 
-.district--Republican {
-    fill: var(--color--Republican);
+.district--grade-2 {
+    fill: var(--color--grade-2);
 }
 
-.district--Republican.district--active {
-    fill: var(--color--Republican--active);
+.district--grade-2.district--active {
+    fill: var(--color--grade-2--active);
+}
+
+.district--grade-3 {
+    fill: var(--color--grade-3);
+}
+
+.district--grade-3.district--active {
+    fill: var(--color--grade-3--active);
 }
 
 .leaflet-control-search .search-input {


### PR DESCRIPTION
Towards #43.

## Changes

- Parse EDR Data Google Sheet into JSON
- Join EDR Data with existing legislature data
- Color districts according to legislator grade
- Add legend for district colors

## TODO

- [ ] I'm not sure about the green color scheme; I think it might make it hard to distinguish the level of support. Do we need 4 grades? Could we use distinct colors for each? That's how the map on https://actonmass.org/the-campaign/ works.

<img width="741" alt="Screen Shot 2021-02-11 at 8 18 14 PM" src="https://user-images.githubusercontent.com/1326704/107719763-f4101e00-6ca6-11eb-8e35-2e36094afce9.png">

<img width="751" alt="Screen Shot 2021-02-11 at 8 17 25 PM" src="https://user-images.githubusercontent.com/1326704/107719778-fa05ff00-6ca6-11eb-94c7-d470b2f23ccf.png">
