### PR TITLE
Add hyperlinks to Early/Mail letter

### DIFF
--- a/pages/campaign-finance-letter.js
+++ b/pages/campaign-finance-letter.js
@@ -22,7 +22,7 @@ function CampaignFinanceLetter() {
         Signed,
       </p>
       <p Style="text-indent:1cm">
-        The Good Governance Project
+        <i>The Good Governance Project</i>
       </p>
     </Layout>
   );

--- a/pages/early-mail-voting-letter.js
+++ b/pages/early-mail-voting-letter.js
@@ -7,31 +7,70 @@ function EarlyMailVotingLetter() {
         Dear elected officials,
       </p>
       <p Style="text-indent:1cm">
-        We write to you today to in support of establishing permanent mail-in-voting for Massachusetts residents and to urge you to vote for legislation like SD. 39, an Act modernizing access and improving laws in voting.
+        We write to you today to in support of establishing permanent mail-in-voting for Massachusetts
+        residents and to urge you to vote for legislation like
+        <a href="https://malegislature.gov/Bills/192/SD39"> SD. 39, an Act modernizing access and improving laws in voting.</a>
       </p>
       <p Style="text-indent:1cm">
-        Representative democracy requires political participation, but, as our history has taught us and as we have observed in recent elections, our political system alone does not guarantee an active citizenry or their equal access to polling places and voting mechanisms. While Massachusetts and our country have come a long way from enfranchising only white, male landowners, there is always more work to be done in pursuit of a “more perfect union.” We must continually strive to improve our electoral systems and work towards full civic participation.
+        Representative democracy requires political participation, but, as our history has taught us and as we have
+        <a href="https://www.aclu.org/news/civil-liberties/block-the-vote-voter-suppression-in-2020/" > observed in recent elections</a>,
+        our political system alone does not guarantee an
+        active citizenry or their equal access to polling places and voting mechanisms. While Massachusetts
+        and our country have come a long way from enfranchising only white, male landowners, there is always
+        more work to be done in pursuit of a “more perfect union.” We must continually strive to improve our
+        electoral systems and work towards full civic participation.
       </p>
       <p Style="text-indent:1cm">
-        Massachusetts has plenty of room for growth. According to the Secretary of State’s website, 76% of registered voters turned out to vote in the 2020 general election, while only 36.58% turned out for the 2020 state primaries and 37.11% for the 2020 presidential primaries. With few exceptions in the presidential primaries, those figures represent the highest turnout in Massachusetts in at least 20 years. It might be tempting to feel reassurance in a 76% turnout figure, because, after all, enabling that many registered voters to cast their vote during a pandemic is no small achievement. However, participation in presidential elections represent a small part of a voter’s civic responsibility, and the success of 2020 election stems largely from the emergency acts smartly passed by the Legislature in response to COVID-19 (see St.2020 c.115 and St.2020 c.255). Among the temporary changes made to our election systems was a relaxing of vote-by-mail (absentee ballot) restrictions, allowing individuals from across the state to vote early and by absentee ballot. 42% of registered voters in the Commonwealth took advantage of the relatively easy means to vote and would likely do so again if given the opportunity.
+        Massachusetts has plenty of room for growth. According to the
+        <a href="file:///C:/Users/msvic/AppData/Local/Packages/microsoft.windowscommunicationsapps_8wekyb3d8bbwe/LocalState/Files/S0/2796/Attachments/sec.state.ma.us/ele/elevoterturnoutstats/voterturnoutstats.htm"> Secretary of State’s website</a>,
+        76% of registered voters turned out to vote in the 2020 general election, while only 36.58% turned out for
+        the 2020 state primaries and 37.11% for the 2020 presidential primaries. With few exceptions in the
+        presidential primaries, those figures represent the highest turnout in Massachusetts in at least 20 years.
+        It might be tempting to feel reassurance in a 76% turnout figure, because, after all, enabling that many
+        registered voters to cast their vote during a pandemic is no small achievement. However, participation in
+        presidential elections represent a small part of a voter’s civic responsibility, and the success of 2020
+        election stems largely from the emergency acts smartly passed by the Legislature in response to
+        COVID-19 (see <a href="https://malegislature.gov/Laws/SessionLaws/Acts/2020/Chapter115"> St.2020 c.115 </a>
+        and <a href="https://malegislature.gov/Laws/SessionLaws/Acts/2020/Chapter255"> St.2020 c.255</a>).
+        Among the temporary changes made to our election systems was a relaxing of vote-by-mail (absentee ballot) restrictions, allowing individuals from across the state
+        to vote early and by absentee ballot. <a href="https://www.bostonherald.com/2020/11/20/mail-in-ballots-made-up-42-of-massachusetts-votes-cast-in-november-election/"> 42% of registered voters in the Commonwealth took advantage of the
+        relatively easy means to vote </a> and would likely do so again if given the opportunity.
       </p>
       <p Style="text-indent:1cm">
-        Like most efforts worth their while, establishing voluntary, permanent mail-in-voting will require time, energy, and money. It will require thoughtful planning and careful execution. But it is well within our means, as evidenced by its successful implementation in the 2020 election, and it is a moral imperative. Representative democracy is stronger when more constituents participate in elections, and turnout is highest when participation is made easy. It is worth remembering that whatever costs and efforts are borne by the State, which exists to serve the people, translate into time and effort saved on the part of registered voters.
+        Like most efforts worth their while, establishing voluntary, permanent mail-in-voting will require time,
+        energy, and money. It will require thoughtful planning and careful execution. But it is well within our
+        means, as evidenced by its successful implementation in the 2020 election, and it is a moral imperative.
+        Representative democracy is stronger when more constituents participate in elections, and turnout is highest
+        when participation is made easy. It is worth remembering that whatever costs and efforts are borne by the
+        State, which exists to serve the people, translate into time and effort saved on the part of registered voters.
       </p>
       <p Style="text-indent:1cm">
-        Legislation such as SD. 39, an act modernizing access and improving laws in voting, establishes clear processes to support permanent mail-in-voting and timelines for their enactment. The act also provides for modernization of our technologically-regressive central registry, something that the Legislature previously mandated in Bill H. 4667, an Act automatically registering eligible voters and enhancing safeguards against fraud and a system that will aid the Secretary’s efforts in enacting permanent mail-in-voting. At present, Massachusetts is among the minority of states that has not adopted Electronic Registration Information Center (ERIC) and moved to a centralized, digital registry.
+        Legislation such as SD. 39, an act modernizing access and improving laws in voting, establishes clear
+        processes to support permanent mail-in-voting and timelines for their enactment. The act also provides for
+        modernization of our technologically-regressive central registry, something that the Legislature previously
+        mandated in <a href="https://malegislature.gov/Bills/190/H4671"> Bill H. 4667, an Act automatically registering eligible voters and enhancing safeguards against
+        fraud </a> and a system that will aid the Secretary’s efforts in enacting permanent mail-in-voting. At present,
+        Massachusetts is among the <a href="https://ericstates.org/"> minority of states that has not adopted Electronic Registration Information
+        Center (ERIC) </a> and moved to a centralized, digital registry.
       </p>
       <p Style="text-indent:1cm">
-        SD. 39 also provides for a modest expansion of the employee’s right to take 2 hours from the workday to vote, primaries held earlier in the year relative to national elections, improved access to polling places at institutions for higher education, an increase in and standardization of the number of drop boxes in voting districts, and automatic permanent mail-in-voter registration for those registered voters who participated by absentee ballot for both the 2020 state primary and presidential election. We believe these to be smart, effective measures that will substantially improve access to the ballot.
+        SD. 39 also provides for a modest expansion of the employee’s right to take 2 hours from the workday to vote,
+        primaries held earlier in the year relative to national elections, improved access to polling places at
+        institutions for higher education, an increase in and standardization of the number of drop boxes in voting
+        districts, and automatic permanent mail-in-voter registration for those registered voters who participated
+        by absentee ballot for both the 2020 state primary and presidential election. We believe these to be smart,
+        effective measures that will substantially improve access to the ballot.
       </p>
       <p Style="text-indent:1cm">
-        It is time to take the next step on the long road to a full participatory democracy. Please consider sponsoring and supporting legislation that expands your constituents’ access to the ballot, especially those initiatives that provide for permanent mail-in-voting.
+        It is time to take the next step on the long road to a full participatory democracy. Please consider
+        sponsoring and supporting legislation that expands your constituents’ access to the ballot, especially those
+        initiatives that provide for permanent mail-in-voting.
       </p>
       <p Style="text-indent:1cm">
         Signed,
       </p>
       <p Style="text-indent:1cm">
-        The Good Governance Project
+        <i>The Good Governance Project</i>
       </p>
     </Layout>
   );

--- a/pages/edr-letter.js
+++ b/pages/edr-letter.js
@@ -26,7 +26,7 @@ function EDRLetter() {
         Signed,
       </p>
       <p Style="text-indent:1cm">
-        The Good Governance Project
+        <i>The Good Governance Project</i>
       </p>
     </Layout>
   );


### PR DESCRIPTION
1. Added the hyperlinks to the Early/Mail Voting letter as they were in
the Word document.
2. Italicized the group name after each letter's signed portion.