### PR TITLE
Recolor Icon Clusters

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -342,7 +342,17 @@ class Map extends Component {
         const thirdPartyIconCluster = (features) => {
 
           // setup clustering, initialize seen cluster 
-          var iconClusters = L.markerClusterGroup();
+          var iconClusters = L.markerClusterGroup({
+            iconCreateFunction: function(cluster) {
+              return L.divIcon({ 
+                html: '<b>' + cluster.getChildCount() + '</b>',
+                className:'thirdPartyCluster',
+                iconSize: L.point(36, 36)
+              });
+            }
+          });
+
+          // var iconClusters = L.markerClusterGroup();
 
           // loop over the features to add all the icons and popup logic
           //   add the layers to the clusterGroup along the way

--- a/styles/Map.css
+++ b/styles/Map.css
@@ -143,3 +143,13 @@
     margin: 0;
     border-radius: 0;
 }
+
+.thirdPartyCluster {
+    font-size: 1.1rem;
+    color: white;
+    background-color: rgba(100, 100, 100, 0.8);
+    border-radius: 50%;
+    /* Janky way to center the text, eek */
+    padding-top: 5px;
+    padding-left: 13px;
+}


### PR DESCRIPTION
Changed icon clusters to a neutral grey color. Functionality still the same.

See image below for reference:
<img width="359" alt="Screen Shot 2021-03-13 at 11 04 11 AM" src="https://user-images.githubusercontent.com/59549713/111036250-4fd7df00-83ec-11eb-85d9-e517e85bddd9.png">
