### PR TITLE
Moved poster images under GGP paragraphs

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -55,29 +55,47 @@ function About() {
             , these three priorities reflect the impactful, pragmatic, and common
             ground changes the GGP hopes to advance.
           </p>
-          {/* <div className="firstTwoPosters">
+
+          <div className={style.posterContainer}>
             <div>
               <h3>Learn with us - click a poster to watch!</h3>
             </div>
             <div className={style.learnWithPosters}>
-              <div className="posterImgLink" id="rightPoster">
-                <a href="https://bccte.zoom.us/webinar/register/WN_e-d5HI5zQXusUC6WOsAT2w" target="_blank" rel="noreferrer">
-                  <img src={faithDemocracy} className={style.posterImages} alt="" />
-                </a>
+              <div className={style.firstPosterCol}>
+                <div className={style.posterImgLink} id="rightPoster">
+                  <a href="https://bccte.zoom.us/webinar/register/WN_e-d5HI5zQXusUC6WOsAT2w" target="_blank" rel="noreferrer">
+                    <img src={faithDemocracy} className={style.posterImages} alt="" />
+                  </a>
+                </div>
+                <div className={style.posterImgLink} id="leftPoster">
+                  <a href="https://www.youtube.com/watch?v=XF2IGKopwdk" target="_blank" rel="noreferrer">
+                    <img src={democracyReform} className={style.posterImages} alt="" />
+                  </a>
+                </div>
               </div>
-              <div className="posterImgLink" id="leftPoster">
-                <a href="https://www.youtube.com/watch?v=XF2IGKopwdk" target="_blank" rel="noreferrer">
-                  <img src={democracyReform} className={style.posterImages} alt="" />
-                </a>
+
+              <div className={style.secondPosterCol}>
+                <div className={style.posterImgLink} id="middlePoster1">
+                  <a href="https://www.youtube.com/watch?v=utCYTU3miOg&t=3s" target="_blank" rel="noreferrer">
+                    <img src={racialJustice} className={style.posterImages} alt="" />
+                  </a>
+                </div>
+                <div className={style.posterImgLink} id="middlePoster2">
+                  <a href="https://www.youtube.com/watch?v=DLjdC8BFlvY&t=34s" target="_blank" rel="noreferrer">
+                    <img src={privacyDemocracy} className={style.posterImages} alt="" />
+                  </a>
+                </div>
               </div>
+
             </div>
-            </div> */}
+          </div>
+
         </div>
 
         <Twitter/>
       </div>
 
-      <div className={style.posterContainer}>
+      {/* <div className={style.posterContainer}>
         <div>
           <h3>Learn with us - click a poster to watch!</h3>
         </div>
@@ -109,7 +127,7 @@ function About() {
           </div>
 
         </div>
-      </div>
+      </div> */}
 
       <div className={style.sharedValues}>
         <h3>GGP Statement of Shared Values</h3>


### PR DESCRIPTION
Repositioned poster images to sit under the two paragraphs next to the Twitter component on the about page.