### PR TITLE
Update profile, add name to testimony

### DIFF
--- a/components/db/profile.ts
+++ b/components/db/profile.ts
@@ -8,10 +8,13 @@ export type ProfileMember = {
   id: string
   name: string
 }
+
 export type Profile = {
+  displayName?: string
   representative?: ProfileMember
   senator?: ProfileMember
 }
+
 export type ProfileHook = ReturnType<typeof useProfile>
 
 type ProfileState = {

--- a/components/db/testimony/types.ts
+++ b/components/db/testimony/types.ts
@@ -17,6 +17,7 @@ export type DraftTestimony = BaseTestimony & {
 /** Published testimony */
 export type Testimony = BaseTestimony & {
   authorUid: string
+  authorDisplayName: string
   version: number
   publishedAt: Timestamp
 }

--- a/components/db/testimony/useEditTestimony.test.ts
+++ b/components/db/testimony/useEditTestimony.test.ts
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react"
 import { act, renderHook } from "@testing-library/react-hooks"
+import { User } from "firebase/auth"
 import { DraftTestimony, Testimony, useEditTestimony } from "."
 import {
   createFakeBill,
@@ -9,8 +10,9 @@ import {
 import { terminateFirebase } from "../../../tests/testUtils"
 
 let uid: string
+let user: User
 beforeEach(async () => {
-  const user = await signInUser1()
+  user = await signInUser1()
   uid = user.uid
 })
 
@@ -34,6 +36,7 @@ beforeEach(() => {
   }
   testimony = {
     authorUid: uid,
+    authorDisplayName: user.displayName!,
     billId,
     content: draft.content,
     court: 192,

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,8 +7,9 @@ service cloud.firestore {
       allow write: if false;
     }
     match /profiles/{uid} {
-      // private, only accessible by the user
-      allow read, write: if request.auth.uid == uid
+      // public, only writeable by the user
+      allow read: if true
+      allow write: if request.auth.uid == uid
     }
     // Allow querying publications individually or with a collection group.
     match /{path=**}/publishedTestimony/{id} {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,8 +1,9 @@
 export { fetchBillBatch, startBillBatches } from "./bills"
 export {
+  createMemberSearchIndex,
   fetchMemberBatch,
-  startMemberBatches,
-  createMemberSearchIndex
+  startMemberBatches
 } from "./members"
-export { publishTestimony, deleteTestimony } from "./testimony"
+export { setUsername } from "./profile"
+export { deleteTestimony, publishTestimony } from "./testimony"
 export * from "./triggerScheduledFunction"

--- a/functions/src/profile.ts
+++ b/functions/src/profile.ts
@@ -1,0 +1,8 @@
+import * as functions from "firebase-functions"
+import { db } from "./firebase"
+
+export const setUsername = functions.auth.user().onCreate(async user => {
+  if (user.displayName) {
+    await db.doc(`/profiles/${user.uid}`).set({ displayName: user.displayName })
+  }
+})

--- a/functions/src/testimony/types.ts
+++ b/functions/src/testimony/types.ts
@@ -26,6 +26,7 @@ export type Testimony = Static<typeof Testimony>
 export const Testimony = withDefaults(
   BaseTestimony.extend({
     authorUid: Id,
+    authorDisplayName: RtString,
     version: Number,
     publishedAt: InstanceOf(Timestamp)
   }),

--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -26,3 +26,13 @@ export async function createFakeBill() {
   await testDb.doc(`/generalCourts/192/bills/${billId}`).create(bill)
   return billId
 }
+
+export async function expectPermissionDenied(work: Promise<any>) {
+  const warn = console.warn
+  console.warn = jest.fn()
+  const e = await work
+    .then(() => fail("expected promise to reject"))
+    .catch(e => e)
+  expect(e.code).toBe("permission-denied")
+  console.warn = warn
+}

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -30,7 +30,7 @@ describe("profile", () => {
         profile = await getProfile(newUser.uid)
         expect(profile).toBeTruthy()
       },
-      { timeout: 1000, interval: 250 }
+      { timeout: 5000, interval: 250 }
     )
     return profile
   }

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -1,0 +1,67 @@
+import { waitFor } from "@testing-library/react"
+import { signInWithEmailAndPassword } from "firebase/auth"
+import { doc, getDoc, setDoc } from "firebase/firestore"
+import { nanoid } from "nanoid"
+import { auth, firestore } from "../../components/firebase"
+import { terminateFirebase, testAuth, testDb } from "../testUtils"
+import { expectPermissionDenied, signInUser1 } from "./common"
+
+const fakeUser = () => ({
+  uid: nanoid(),
+  displayName: "Conan O'Brien",
+  email: `${nanoid()}@example.com`,
+  password: "password"
+})
+
+const getProfile = (uid: string) =>
+  testDb
+    .doc(`/profiles/${uid}`)
+    .get()
+    .then(d => d.data())
+
+afterAll(terminateFirebase)
+
+describe("profile", () => {
+  async function expectProfile(newUser: any) {
+    await testAuth.createUser(newUser)
+    let profile: any
+    await waitFor(
+      async () => {
+        profile = await getProfile(newUser.uid)
+        expect(profile).toBeTruthy()
+      },
+      { timeout: 1000, interval: 250 }
+    )
+    return profile
+  }
+
+  it("Sets the display name for new users", async () => {
+    const expected = fakeUser()
+    await expect(getProfile(expected.uid)).resolves.toBeUndefined()
+    const profile = await expectProfile(expected)
+    expect(profile?.displayName).toEqual(expected.displayName)
+  })
+
+  it("Is publicly readable", async () => {
+    const newUser = fakeUser()
+    await expectProfile(newUser)
+
+    await signInUser1()
+    const result = await getDoc(doc(firestore, `profiles/${newUser.uid}`))
+    expect(result.exists()).toBeTruthy()
+  })
+
+  it("Can only be modified by the logged in user", async () => {
+    const newUser = fakeUser()
+    const profileRef = doc(firestore, `profiles/${newUser.uid}`)
+    await expectProfile(newUser)
+
+    await signInUser1()
+    await expectPermissionDenied(setDoc(profileRef, { displayName: "test" }))
+
+    await signInWithEmailAndPassword(auth, newUser.email, newUser.password)
+    await expect(
+      setDoc(profileRef, { displayName: "test" })
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Make profiles publicly readable.

You can now get the name of the author with `testimony.authorDisplayName`
