### PR TITLE
Specify useEffect dependencies for snapshot listeners

### DIFF
--- a/components/db/testimony/useEditTestimony.ts
+++ b/components/db/testimony/useEditTestimony.ts
@@ -34,7 +34,7 @@ interface UseEditTestimony {
   draft?: DraftTestimony
   /** The current published version of the testimony, if any.  */
   publication?: Testimony
-  
+
   /** Saves the given `position` and `content` to the draft version of the
    * testimony. This should not be called while the hook is `loading` or has an
    * `error`.
@@ -156,7 +156,7 @@ function useTestimony(
           }),
         error: error => dispatch({ type: "error", error })
       })
-  })
+  }, [dispatch, publicationRef])
 }
 
 function usePublishTestimony(

--- a/components/db/testimony/useTestimonyListing.ts
+++ b/components/db/testimony/useTestimonyListing.ts
@@ -24,24 +24,28 @@ export function useTestimonyListing(uid: string) {
   const [{ draftsLoading, publicationsLoading, error, testimony }, dispatch] =
     useReducer(reducer, initialState)
 
-  useEffect(() =>
-    onSnapshot(
-      query(
-        collectionGroup(firestore, "publishedTestimony"),
-        where("authorUid", "==", uid)
+  useEffect(
+    () =>
+      onSnapshot(
+        query(
+          collectionGroup(firestore, "publishedTestimony"),
+          where("authorUid", "==", uid)
+        ),
+        {
+          next: snapshot => dispatch({ type: "updatePublications", snapshot }),
+          error: error => dispatch({ type: "error", error })
+        }
       ),
-      {
-        next: snapshot => dispatch({ type: "updatePublications", snapshot }),
-        error: error => dispatch({ type: "error", error })
-      }
-    )
+    [uid]
   )
 
-  useEffect(() =>
-    onSnapshot(query(collection(firestore, `users/${uid}/draftTestimony`)), {
-      next: snapshot => dispatch({ type: "updateDrafts", snapshot }),
-      error: error => dispatch({ type: "error", error })
-    })
+  useEffect(
+    () =>
+      onSnapshot(query(collection(firestore, `users/${uid}/draftTestimony`)), {
+        next: snapshot => dispatch({ type: "updateDrafts", snapshot }),
+        error: error => dispatch({ type: "error", error })
+      }),
+    [uid]
   )
 
   return useMemo(


### PR DESCRIPTION
Without deps, useEditTestimony was getting caught in a render loop if you were on a page where you had posted testimony, leading to a bunch of reads. This fixes the render loop issue.

I did find [some documentation](https://firebase.google.com/docs/firestore/best-practices) that said snapshot listeners should be relatively long-lived, at least 30 seconds, for best performance. The way we use them, they generally aren't, so we may want to switch over to one-shot queries with periodic retries. the 