### PR TITLE
if user has already posted testimony on a bill:

### DIFF
--- a/components/AddTestimony/AddTestimony.js
+++ b/components/AddTestimony/AddTestimony.js
@@ -1,7 +1,8 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Button, Modal } from "react-bootstrap"
 import { useAuth } from "../../components/auth"
 import CommentModal from "../CommentModal/CommentModal"
+import { usePublishedTestimonyListing } from "../db"
 
 const AddTestimony = ({ bill, committeeName, committeeChairEmail }) => {
   const [showTestimony, setShowTestimony] = useState(false)
@@ -9,11 +10,27 @@ const AddTestimony = ({ bill, committeeName, committeeChairEmail }) => {
   const handleShowTestimony = () => setShowTestimony(true)
   const handleCloseTestimony = () => setShowTestimony(false)
   const { authenticated, user } = useAuth()
+
+  const published = usePublishedTestimonyListing({ uid: user?.uid })
+  const [isPublished, setIsPublished] = useState(false)
+
+  useEffect(() => {
+    const userTestimonies = published?.result?.filter(
+      u => u.authorUid === user?.uid && bill.BillNumber === u.billId
+    )
+
+    setIsPublished(userTestimonies?.length !== 0)
+  }, [bill.BillNumber, published?.result, user?.uid])
+
   return (
     <>
       <div className="d-flex justify-content-center">
         <Button variant="primary" onClick={handleShowTestimony}>
-          {authenticated ? "Add your voice" : "Sign in to add your voice"}
+          {!authenticated
+            ? "Sign in to add your voice"
+            : isPublished
+            ? "Edit your testimony"
+            : "Add your voice"}
         </Button>
       </div>
 

--- a/components/CommentModal/CommentModal.js
+++ b/components/CommentModal/CommentModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Button, Modal } from "react-bootstrap"
 import { useAuth } from "../../components/auth"
 import { useProfile, useMember } from "../db"
@@ -43,6 +43,11 @@ My thoughts:
   const representativeEmail = representative.member?.EmailAddress ?? ""
 
   const edit = useEditTestimony(user ? user.uid : null, bill.BillNumber)
+
+  useEffect(() => {
+    const testimony = edit.draft ? edit.draft : defaultTestimony
+    setTestimony(testimony)
+  }, [defaultTestimony, edit.draft])
 
   const positionMessage = "Select my support..(required)"
 
@@ -110,7 +115,7 @@ My thoughts:
   }
 
   const positionChosen =
-    testimony.position != undefined && testimony.position != positionMessage
+    testimony?.position != undefined && testimony.position != positionMessage
 
   return (
     <Modal show={showTestimony} onHide={handleCloseTestimony} size="lg">


### PR DESCRIPTION
comment modal shows existing testimony instead of default
button says "edit your testimony" instead of "add your voice"
addresses issue #313 
--
ran prettier