### PR TITLE
#309 Wire up profile public checkbox

### DIFF
--- a/components/db/profile.ts
+++ b/components/db/profile.ts
@@ -14,6 +14,7 @@ export type Profile = {
   displayName?: string
   representative?: ProfileMember
   senator?: ProfileMember
+  public?: boolean
 }
 
 export type ProfileHook = ReturnType<typeof useProfile>
@@ -22,6 +23,7 @@ type ProfileState = {
   loading: boolean
   updatingRep: boolean
   updatingSenator: boolean
+  updatingIsPublic: boolean
   profile: Profile | undefined
 }
 
@@ -39,6 +41,7 @@ export function useProfile() {
         loading: true,
         updatingRep: false,
         updatingSenator: false,
+        updatingIsPublic: false,
         profile: undefined
       }
     )
@@ -66,6 +69,13 @@ export function useProfile() {
           await updateRepresentative(uid, rep)
           dispatch({ updatingRep: false })
         }
+      },
+      updateIsPublic: async (isPublic: boolean) => {
+        if (uid) {
+          dispatch({ updatingIsPublic: true })
+          await updateIsPublic(uid, isPublic)
+          dispatch({ updatingIsPublic: false })
+        }
       }
     }),
     [uid]
@@ -87,6 +97,10 @@ function updateRepresentative(uid: string, representative: ProfileMember) {
 
 function updateSenator(uid: string, senator: ProfileMember) {
   return setDoc(profileRef(uid), { senator }, { merge: true })
+}
+
+function updateIsPublic(uid: string, isPublic: boolean) {
+  return setDoc(profileRef(uid), { public: isPublic }, { merge: true })
 }
 
 export function usePublicProfile(uid: string) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -15,7 +15,7 @@ service cloud.firestore {
       // Always visible by the user,
       // and public if profile.public is true or undefined (defaults to true).
       // Only writeable by the user.
-      allow read: if request.resource.data.public || request.resource.data.public == undefined || request.auth.uid == uid
+      allow read: if !("public" in resource.data) || resource.data.public || request.auth.uid == uid
       allow write: if request.auth.uid == uid
     }
     // Allow querying publications individually or with a collection group.

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,8 +12,10 @@ service cloud.firestore {
       allow write: if false;
     }
     match /profiles/{uid} {
-      // public, only writeable by the user
-      allow read: if true
+      // Always visible by the user,
+      // and public if profile.public is true or undefined (defaults to true).
+      // Only writeable by the user.
+      allow read: if request.resource.data.public || request.resource.data.public == undefined || request.auth.uid == uid
       allow write: if request.auth.uid == uid
     }
     // Allow querying publications individually or with a collection group.

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
     "react-twitter-embed": "^4.0.4",
     "sidebar-v2": "^0.4.0",
     "styled-components": "^5.3.3",
-    "web-vitals": "^0.2.4",
-    "yarn": "1.22.18"
+    "web-vitals": "^0.2.4"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "react-twitter-embed": "^4.0.4",
     "sidebar-v2": "^0.4.0",
     "styled-components": "^5.3.3",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "yarn": "1.22.18"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.2",

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,15 +1,17 @@
 import React from "react"
 import { requireAuth } from "../components/auth"
+import { useProfile } from "../components/db"
 import * as links from "../components/links"
 import { createPage } from "../components/page"
 import SelectLegislators from "../components/SelectLegislators"
 import MyTestimonies from "../components/MyTestimonies/MyTestimonies"
-import { Row, Col, FormControl } from "react-bootstrap"
+import { Row, Col, FormControl, Spinner } from "react-bootstrap"
 
 export default createPage({
   v2: true,
   title: "Profile",
   Page: requireAuth(({ user: { displayName } }) => {
+    const profile = useProfile()
     return (
       <>
         <h1>
@@ -48,18 +50,26 @@ export default createPage({
           </Col>
           <Col></Col>
         </Row>
-        <div className="form-check mt-3 mb-2">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="flexCheckChecked"
-            defaultChecked={true}
-            // checked={true}  // complete when OnChange is ready
-          />
-          <label className="form-check-label" htmlFor="flexCheckChecked">
-            Allow others to see my profile
-          </label>
-        </div>
+        {!profile.loading ? (
+          <div className="form-check mt-3 mb-2">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              id="flexCheckChecked"
+              defaultChecked={true}
+              checked={profile.profile?.public ?? true} // complete when OnChange is ready
+              onChange={e => {
+                profile.updateIsPublic(e.target.checked)
+              }}
+            />
+            <label className="form-check-label" htmlFor="flexCheckChecked">
+              Allow others to see my profile&nbsp;
+            </label>
+            {profile.updatingIsPublic ? (
+              <Spinner animation="border" className="mx-auto" size="sm" />
+            ) : null}
+          </div>
+        ) : null}
         <MyTestimonies />
       </>
     )

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -56,7 +56,6 @@ export default createPage({
               className="form-check-input"
               type="checkbox"
               id="flexCheckChecked"
-              defaultChecked={true}
               checked={profile.profile?.public ?? true} // complete when OnChange is ready
               onChange={e => {
                 profile.updateIsPublic(e.target.checked)

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -56,7 +56,7 @@ export default createPage({
               className="form-check-input"
               type="checkbox"
               id="flexCheckChecked"
-              checked={profile.profile?.public ?? true} // complete when OnChange is ready
+              checked={profile.profile?.public ?? true} // default is true
               onChange={e => {
                 profile.updateIsPublic(e.target.checked)
               }}

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -53,6 +53,7 @@ describe("profile", () => {
 
   it("Is publicly readable when public", async () => {
     const newUser = fakeUser()
+    await signInUser(newUser.email)
     const profileRef = doc(firestore, `profiles/${newUser.uid}`)
     setDoc(profileRef, { public: true })
     await expectProfile(newUser)
@@ -64,11 +65,11 @@ describe("profile", () => {
 
   it("Is not publicly readable when not public", async () => {
     const newUser = fakeUser()
+    await signInUser(newUser.email)
     const profileRef = doc(firestore, `profiles/${newUser.uid}`)
     setDoc(profileRef, { public: false })
     await expectProfile(newUser)
 
-    await signInUser(newUser.email)
     const result = await getDoc(doc(firestore, `profiles/${newUser.uid}`))
     expect(result.exists()).toBeTruthy()
   })
@@ -76,6 +77,7 @@ describe("profile", () => {
   it("Is readable when not public by own user", async () => {
     const newUser = fakeUser()
     const profileRef = doc(firestore, `profiles/${newUser.uid}`)
+    await signInUser(newUser.email)
     setDoc(profileRef, { public: false })
     await expectProfile(newUser)
 

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -54,7 +54,7 @@ describe("profile", () => {
   it("Is publicly readable when public", async () => {
     const user1 = await signInUser1()
     const profileRef = doc(firestore, `profiles/${user1.uid}`)
-    setDoc(profileRef, { public: true })
+    await setDoc(profileRef, { public: true })
 
     await signInUser2()
     const result = await getDoc(doc(firestore, `profiles/${user1.uid}`))
@@ -64,7 +64,7 @@ describe("profile", () => {
   it("Is not publicly readable when not public", async () => {
     const user1 = await signInUser1()
     const profileRef = doc(firestore, `profiles/${user1.uid}`)
-    setDoc(profileRef, { public: false })
+    await setDoc(profileRef, { public: false })
 
     await signInUser2()
     await expectPermissionDenied(
@@ -75,7 +75,7 @@ describe("profile", () => {
   it("Is readable when not public by own user", async () => {
     const user1 = await signInUser1()
     const profileRef = doc(firestore, `profiles/${user1.uid}`)
-    setDoc(profileRef, { public: false })
+    await setDoc(profileRef, { public: false })
 
     const result = await getDoc(doc(firestore, `profiles/${user1.uid}`))
     expect(result.exists()).toBeTruthy()

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -6,7 +6,6 @@ import { auth, firestore } from "../../components/firebase"
 import { terminateFirebase, testAuth, testDb } from "../testUtils"
 import {
   expectPermissionDenied,
-  signInUser,
   signInUser1,
   signInUser2
 } from "./common"

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -80,7 +80,7 @@ describe("profile", () => {
     await expectProfile(newUser)
 
     await signInUser1()
-    expectPermissionDenied(getDoc(doc(firestore, `profiles/${newUser.uid}`)))
+    await expectPermissionDenied(getDoc(doc(firestore, `profiles/${newUser.uid}`)))
   })
 
   it("Can only be modified by the logged in user", async () => {

--- a/tests/integration/profile.test.ts
+++ b/tests/integration/profile.test.ts
@@ -4,11 +4,7 @@ import { doc, getDoc, setDoc } from "firebase/firestore"
 import { nanoid } from "nanoid"
 import { auth, firestore } from "../../components/firebase"
 import { terminateFirebase, testAuth, testDb } from "../testUtils"
-import {
-  expectPermissionDenied,
-  signInUser1,
-  signInUser2
-} from "./common"
+import { expectPermissionDenied, signInUser1, signInUser2 } from "./common"
 
 const fakeUser = () => ({
   uid: nanoid(),


### PR DESCRIPTION
# Overview

Hooks up the profile checkbox on users' personal profile pages, so that it only allows users to view another user's profile if that profile is public (as it is by default).

# Verification Steps:

- [x] Try visiting public profile as that user when public is true (should work)
- [x] Try visiting public profile as that user when public is false (should work)
- [x] Try visiting public profile as a different user when public is true (should work)
- [x] Try visiting public profile as a different user when public is false (should NOT work)
- [x] Try visiting public profile of a new user (with public unset) as a different user (should work)