### PR TITLE
redirect to login page from add your voice button

### DIFF
--- a/components/AddTestimony/AddTestimony.js
+++ b/components/AddTestimony/AddTestimony.js
@@ -3,6 +3,7 @@ import { Button, Modal } from "react-bootstrap"
 import { useAuth } from "../../components/auth"
 import CommentModal from "../CommentModal/CommentModal"
 import { usePublishedTestimonyListing } from "../db"
+import { useRouter } from "next/router"
 
 const AddTestimony = ({
   bill,
@@ -12,7 +13,16 @@ const AddTestimony = ({
 }) => {
   const [showTestimony, setShowTestimony] = useState(false)
 
-  const handleShowTestimony = () => setShowTestimony(true)
+  const router = useRouter()
+
+  const handleShowTestimony = () => {
+    if(!authenticated) {
+      router.push("/login")
+     } else {
+    setShowTestimony(true)
+     }
+  }
+
   const handleCloseTestimony = () => setShowTestimony(false)
   const { authenticated, user } = useAuth()
 


### PR DESCRIPTION
PR for issue [356](https://github.com/codeforboston/advocacy-maps/issues/356)

unauthenticated users who click the "add your voice" button under testimonies will now be redirected to login page.  