### PR TITLE
Delete political party indicator from “Lead Sponsor” column

### DIFF
--- a/components/ViewBills/ViewBills.js
+++ b/components/ViewBills/ViewBills.js
@@ -35,7 +35,7 @@ const BillRow = props => {
         <links.External href={sponsorURL}>
           {bill.PrimarySponsor.Name}
         </links.External>
-        - {member?.Branch} - {member?.District} - {member?.Party}
+        - {member?.Branch} - {member?.District} 
       </>
     ) : (
       <>{bill.PrimarySponsor ? bill.PrimarySponsor.Name : null}</>

--- a/components/ViewBills/ViewBills.js
+++ b/components/ViewBills/ViewBills.js
@@ -115,7 +115,7 @@ const ViewBills = () => {
             <th>City</th>
             <th># CoSponsors</th>
             <th>Hearing Scheduled</th>
-            <th># Testimony</th>
+            <th>Published Testimony (#)</th>
             <th>Most Recent Testimony</th>
             <th>Current Committee</th>
           </tr>

--- a/components/ViewBills/ViewBills.js
+++ b/components/ViewBills/ViewBills.js
@@ -115,7 +115,7 @@ const ViewBills = () => {
             <th>City</th>
             <th># CoSponsors</th>
             <th>Hearing Scheduled</th>
-            <th>Published Testimony (#)</th>
+            <th># Testimony</th>
             <th>Most Recent Testimony</th>
             <th>Current Committee</th>
           </tr>


### PR DESCRIPTION
Fix for Issue #381 

Delete political party indicator from “Lead Sponsor” column