### PR TITLE
Remove Bill Title

### DIFF
--- a/components/ViewBillsOnHomePage/ViewBillsOnHomePage.js
+++ b/components/ViewBillsOnHomePage/ViewBillsOnHomePage.js
@@ -23,7 +23,6 @@ const BillRow = props => {
             <Button variant="primary">{formatBillId(bill.BillNumber)}</Button>
           </Wrap>
         </td>
-        <td>{bill.Title}</td>
         <td>{fullBill.nextHearingAt?.toDate().toLocaleDateString()}</td>
       </tr>
     )
@@ -45,7 +44,6 @@ const ViewBills = () => {
         <thead>
           <tr>
             <th>Bill #</th>
-            <th>Bill Name</th>
             <th>Hearing Scheduled</th>
           </tr>
         </thead>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,14 +40,14 @@ export default createPage({
           )}
         </Stack>
         <Row className="mt-4">
-          <Col className="text-center">
+          <Col className="text-center col-12 col-xl-4">
             <Wrap href="/bills">
               <Button size="lg">View All Bills</Button>
             </Wrap>
             <h4 className="mt-3">Bills with Upcoming Hearings</h4>
             <ViewBillsOnHomePage />
           </Col>
-          <Col className="text-center">
+          <Col className="text-center col-12 col-xl-8">
             <Wrap href="/testimonies">
               <Button size="lg">View All Testimony</Button>
             </Wrap>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,14 +40,14 @@ export default createPage({
           )}
         </Stack>
         <Row className="mt-4">
-          <Col className="text-center col-12 col-xl-4">
+          <Col xs={12} xl={4} className="text-center">
             <Wrap href="/bills">
               <Button size="lg">View All Bills</Button>
             </Wrap>
             <h4 className="mt-3">Bills with Upcoming Hearings</h4>
             <ViewBillsOnHomePage />
           </Col>
-          <Col className="text-center col-12 col-xl-8">
+          <Col xs={12} xl={8} className="text-center">
             <Wrap href="/testimonies">
               <Button size="lg">View All Testimony</Button>
             </Wrap>


### PR DESCRIPTION
PR for issue [422](https://github.com/codeforboston/advocacy-maps/issues/422)

Bill Title is removed from homepage table.  

Responsive styling added for xl screens.  Testimony table takes up the majority of the space on xl screen.  

After playing around with the columns for a while, I did not place the tables side by side at a smaller screen size due to spacing/sizing conflicts.  I think that this is the best option visually.  