### PR TITLE
Bill search tweaks

### DIFF
--- a/components/db/bills.ts
+++ b/components/db/bills.ts
@@ -239,7 +239,6 @@ function getPageKey(bill: Bill, sort: SortOptions): unknown {
   }
 }
 
-export type FilterType = FilterOptions["type"]
 export type FilterOptions =
   | { type: "bill"; id: string }
   | { type: "primarySponsor"; id: string }

--- a/components/search/Search.tsx
+++ b/components/search/Search.tsx
@@ -175,10 +175,19 @@ function ItemSearch<T>({
   search,
   ...props
 }: ItemSearchProps<T>) {
-  const error = useInitializeSearch(search)
+  const [error, setError] = useState(false)
   const debouncedLoadOptions = useMemo(
     () =>
-      AwesomeDebouncePromise(async (value: string) => loadOptions(value), 100),
+      AwesomeDebouncePromise(async (value: string) => {
+        try {
+          const options = await loadOptions(value)
+          setError(false)
+          return options
+        } catch (e) {
+          console.warn("Search error", e)
+          setError(true)
+        }
+      }, 100),
     [loadOptions]
   )
   return (
@@ -187,7 +196,6 @@ function ItemSearch<T>({
         {...props}
         instanceId="item-search"
         isClearable
-        defaultOptions
         blurInputOnSelect
         loadOptions={debouncedLoadOptions}
         onChange={i => setFilter(i ? getFilterOption(i) : null)}
@@ -199,24 +207,4 @@ function ItemSearch<T>({
       )}
     </div>
   )
-}
-
-function useInitializeSearch(search: SearchService) {
-  const [error, setError] = useState(false)
-
-  useEffect(
-    () =>
-      void search
-        .initialize()
-        .then(() => {
-          setError(false)
-        })
-        .catch(e => {
-          console.warn("Error initializing search", e)
-          setError(true)
-        }),
-    [search]
-  )
-
-  return error
 }

--- a/components/search/service.tsx
+++ b/components/search/service.tsx
@@ -13,7 +13,7 @@ export const { Provider, useServiceChecked } = createService(() => {
 class BillSearch {
   service = {
     initialize: () => this.getIndex().then(() => {}),
-    bills: this.createSearch(
+    billContents: this.createSearch(
       i => i.bills,
       {
         // Weigh terms that appear at the end of a field the same as those that
@@ -28,6 +28,15 @@ class BillSearch {
         ]
       },
       100
+    ),
+    billIds: this.createSearch(
+      i => i.bills,
+      {},
+      100,
+      index => {
+        index.setKeys(["id"])
+        return index
+      }
     ),
     cities: this.createSearch(i => i.cities, {}, 300),
     committees: this.createSearch(
@@ -76,7 +85,8 @@ class BillSearch {
   private createSearch<T>(
     extract: (i: BillSearchIndex) => { items: T[]; index: any },
     indexOptions: Fuse.IFuseOptions<T> = {},
-    limit = 50
+    limit = 50,
+    prepareIndex: (i: Fuse.FuseIndex<T>) => Fuse.FuseIndex<T> = i => i
   ) {
     let fuse: Fuse<T>
     let items: T[]
@@ -85,7 +95,8 @@ class BillSearch {
         const fullIndex = await this.getIndex()
         const ext = extract(fullIndex)
         items = ext.items
-        fuse = new Fuse(items, indexOptions, Fuse.parseIndex(ext.index))
+        const index = prepareIndex(Fuse.parseIndex(ext.index))
+        fuse = new Fuse(items, indexOptions, index)
       }
     }
 


### PR DESCRIPTION
- split out bill id search, make it default
- wait until search box is focused to load default options. This ensures we only download the index if the user interacts with the search