### PR TITLE
Fix: Changed wording on bills view

### DIFF
--- a/components/ViewBills/ViewBills.js
+++ b/components/ViewBills/ViewBills.js
@@ -97,7 +97,7 @@ const ViewBills = () => {
         <thead>
           <tr>
             <th>Bill #</th>
-            <th>Bill Name</th>
+            <th>Bill Title</th>
             <th>Lead Sponsor</th>
             <th>City</th>
             <th># CoSponsors</th>


### PR DESCRIPTION
- Changed the wording on the bills view from "Bill Name" to "Bill Title"

Related to #416