### PR TITLE
Enforce profile privacy

### DIFF
--- a/components/PublicProfile/PublicProfile.js
+++ b/components/PublicProfile/PublicProfile.js
@@ -9,7 +9,7 @@ const PublicProfile = ({ id }) => {
   const bio = user?.about
   const twit = user?.social?.twitter
   const linkedIn = user?.social?.linkedIn
-  const isPublic = user?.public
+  const isPublic = (user && user.public === undefined) || user?.public === false
 
   const senatorLine = <h4>Senator: {user?.senator?.name}</h4>
   const representativeLine = (
@@ -46,7 +46,7 @@ const PublicProfile = ({ id }) => {
   )
   return (
     <>
-      <h1>{user?.displayName ? user?.displayName : "Name placeholder"}</h1>
+      <h1>{user?.displayName}</h1>
       {isPublic && publicProfile}
       {!isPublic && <h3>Profile is not public</h3>}
     </>

--- a/components/PublicProfile/PublicProfile.js
+++ b/components/PublicProfile/PublicProfile.js
@@ -10,7 +10,6 @@ const PublicProfile = ({ id }) => {
   const twit = user?.social?.twitter
   const linkedIn = user?.social?.linkedIn
   const isPublic = user?.public
-  console.log(isPublic)
 
   const senatorLine = <h4>Senator: {user?.senator?.name}</h4>
   const representativeLine = (

--- a/components/PublicProfile/PublicProfile.js
+++ b/components/PublicProfile/PublicProfile.js
@@ -9,6 +9,8 @@ const PublicProfile = ({ id }) => {
   const bio = user?.about
   const twit = user?.social?.twitter
   const linkedIn = user?.social?.linkedIn
+  const isPublic = user?.public
+  console.log(isPublic)
 
   const senatorLine = <h4>Senator: {user?.senator?.name}</h4>
   const representativeLine = (
@@ -32,9 +34,8 @@ const PublicProfile = ({ id }) => {
     </h4>
   )
 
-  return (
+  const publicProfile = (
     <>
-      <h1>{user?.displayName ? user?.displayName : "Name placeholder"}</h1>
       {user?.senator ? senatorLine : <></>}
       {user?.representative ? representativeLine : <></>}
       {twit ? twitterLine : <></>}
@@ -42,6 +43,13 @@ const PublicProfile = ({ id }) => {
 
       <p>{bio}</p>
       <UserTestimonies authorId={id} />
+    </>
+  )
+  return (
+    <>
+      <h1>{user?.displayName ? user?.displayName : "Name placeholder"}</h1>
+      {isPublic && publicProfile}
+      {!isPublic && <h3>Profile is not public</h3>}
     </>
   )
 }

--- a/components/TestimoniesTable/TestimoniesTable.tsx
+++ b/components/TestimoniesTable/TestimoniesTable.tsx
@@ -54,7 +54,7 @@ const TestimonyRow = ({ testimony }: { testimony: Testimony }) => {
   const profile = usePublicProfile(testimony.authorUid)
 
   const authorPublic = profile.result?.public
-
+  console.log(profile)
   return (
     <tr>
       <td>

--- a/components/TestimoniesTable/TestimoniesTable.tsx
+++ b/components/TestimoniesTable/TestimoniesTable.tsx
@@ -54,7 +54,6 @@ const TestimonyRow = ({ testimony }: { testimony: Testimony }) => {
   const profile = usePublicProfile(testimony.authorUid)
 
   const authorPublic = profile.result?.public
-  console.log(profile)
   return (
     <tr>
       <td>

--- a/components/TestimoniesTable/TestimoniesTable.tsx
+++ b/components/TestimoniesTable/TestimoniesTable.tsx
@@ -51,11 +51,7 @@ const TestimoniesTable = (props: {
 
 const TestimonyRow = ({ testimony }: { testimony: Testimony }) => {
   const { result: bill } = useBill(testimony.billId)
-
-  // this works
-  console.log(testimony.authorUid)
   const profile = usePublicProfile(testimony.authorUid)
-  console.log(profile)
 
   const authorPublic = profile.result?.public
 

--- a/components/TestimoniesTable/TestimoniesTable.tsx
+++ b/components/TestimoniesTable/TestimoniesTable.tsx
@@ -51,7 +51,12 @@ const TestimoniesTable = (props: {
 
 const TestimonyRow = ({ testimony }: { testimony: Testimony }) => {
   const { result: bill } = useBill(testimony.billId)
+
+  // this works
+  console.log(testimony.authorUid)
   const profile = usePublicProfile(testimony.authorUid)
+  console.log(profile)
+
   const authorPublic = profile.result?.public
 
   return (

--- a/components/db/profile.ts
+++ b/components/db/profile.ts
@@ -185,8 +185,11 @@ function updateDisplayName(uid: string, displayName: string) {
   return setDoc(profileRef(uid), { displayName }, { merge: true })
 }
 
-export function usePublicProfile(uid: string) {
-  return useAsync(getProfile, [uid])
+export function usePublicProfile(uid?: string) {
+  return useAsync(
+    () => (uid ? getProfile(uid) : Promise.resolve(undefined)),
+    [uid]
+  )
 }
 
 export async function getProfile(uid: string) {

--- a/pages/testimony.tsx
+++ b/pages/testimony.tsx
@@ -31,11 +31,7 @@ export default createPage({
 
     const { result: bill, loading } = useBill(billId as string)
 
-    // why not working?
-    console.log(testimony?.authorUid)
     const profile = usePublicProfile(testimony?.authorUid)
-    console.log(profile)
-
     const authorPublic = profile.result?.public
 
     return (
@@ -75,11 +71,13 @@ export default createPage({
                     View Bill
                   </Button>
                 </Wrap>
-                <Wrap href={`/publicprofile?id=${author}`}>
-                  <Button variant="primary" className="ms-2">
-                    View User Profile
-                  </Button>
-                </Wrap>
+                {authorPublic && (
+                  <Wrap href={`/publicprofile?id=${author}`}>
+                    <Button variant="primary" className="ms-2">
+                      View User Profile
+                    </Button>
+                  </Wrap>
+                )}
               </div>
             </div>
           </>

--- a/pages/testimony.tsx
+++ b/pages/testimony.tsx
@@ -1,6 +1,10 @@
 import { useRouter } from "next/router"
 import { Button, Spinner } from "react-bootstrap"
-import { useBill, usePublishedTestimonyListing } from "../components/db"
+import {
+  useBill,
+  usePublishedTestimonyListing,
+  usePublicProfile
+} from "../components/db"
 import { formatBillId } from "../components/formatting"
 import { Wrap } from "../components/links"
 import { createPage } from "../components/page"
@@ -26,6 +30,13 @@ export default createPage({
         : undefined
 
     const { result: bill, loading } = useBill(billId as string)
+
+    // why not working?
+    console.log(testimony?.authorUid)
+    const profile = usePublicProfile(testimony?.authorUid)
+    console.log(profile)
+
+    const authorPublic = profile.result?.public
 
     return (
       <>


### PR DESCRIPTION
This is for keeping profiles that are not public hidden.
1) there is no button to see profile on the Testimony page.
2) accessing a profile via the URL is restricted.
for example - a private profile like below should get a "Profile not public" message, where a public profile should display the profile.
sample data:
private profile: http://localhost:3000/publicprofile?id=c8Z3AdZKX0gfEHdQ102AUW14lbG2
public profile: http://localhost:3000/publicprofile?id=CDxcKBZ6BjgetS4C2yuXbB5wgFC2

The author's name should be displayed in either case, as all testimony is attributed to a person.