### PR TITLE
Make testimonies link to their bill in what people are saying section

### DIFF
--- a/components/TestimonyCallout/TestimonyCallout.tsx
+++ b/components/TestimonyCallout/TestimonyCallout.tsx
@@ -1,6 +1,7 @@
 import { Col, Image, Row } from "react-bootstrap"
 import { Testimony } from "../../functions/src/testimony/types"
 import { formatBillId } from "../formatting"
+import * as links from "../links"
 import styles from "./TestimonyCallout.module.css"
 
 export const VoteHand = ({ position }: { position: Testimony["position"] }) => {
@@ -21,39 +22,44 @@ export default function TestimonyCallout(props: Testimony) {
 
   return (
     <Col className="m-auto">
-      <Row className={`row-col-2 ${styles[position]} m-2`}>
-        <Col className="col-auto">
-          <Row className="h-100">
-            <Col
-              className={`${styles.testimonyCalloutContainerTriangle}`}
-            ></Col>
-            <Col className="col-auto my-auto">
-              <VoteHand position={position} />
-            </Col>
-          </Row>
-        </Col>
-        <Col className="">
-          <Row className="m-2">
-            <Col>
-              <Row>
-                <Col
-                  className={`${styles.testimonyCalloutBodyText} align-items-start my-2`}
-                >
-                  {content}
-                </Col>
-              </Row>
-              <Row className="mt-auto mb-2 w-100 justify-content-start">
-                <Col className="col-auto text-white">
-                  Bill {formatBillId(billId)}
-                </Col>
-                <Col className="col-auto text-white ms-auto">
-                  -{authorDisplayName}
-                </Col>
-              </Row>
-            </Col>
-          </Row>
-        </Col>{" "}
-      </Row>
+      <links.Internal
+        href={`/bill?id=${billId}`}
+        className="text-decoration-none"
+      >
+        <Row className={`row-col-2 ${styles[position]} m-2`}>
+          <Col className="col-auto">
+            <Row className="h-100">
+              <Col
+                className={`${styles.testimonyCalloutContainerTriangle}`}
+              ></Col>
+              <Col className="col-auto my-auto">
+                <VoteHand position={position} />
+              </Col>
+            </Row>
+          </Col>
+          <Col className="">
+            <Row className="m-2">
+              <Col>
+                <Row>
+                  <Col
+                    className={`${styles.testimonyCalloutBodyText} align-items-start my-2`}
+                  >
+                    {content}
+                  </Col>
+                </Row>
+                <Row className="mt-auto mb-2 w-100 justify-content-start">
+                  <Col className="col-auto text-white">
+                    Bill {formatBillId(billId)}
+                  </Col>
+                  <Col className="col-auto text-white ms-auto">
+                    -{authorDisplayName}
+                  </Col>
+                </Row>
+              </Col>
+            </Row>
+          </Col>{" "}
+        </Row>
+      </links.Internal>
     </Col>
   )
 }


### PR DESCRIPTION
Closes #549. I went with placing the link below the outermost `Col` because otherwise there is no non-clickable space between the 4 testimonies. 

That being said, with the current implementation the whitespace above the triangle is clickable (see outlined section below), but I don't know an easy way to not do this with the current markup.

![Screen Shot 2022-06-21 at 9 26 13 PM](https://user-images.githubusercontent.com/10203352/174923796-7c02f34e-6c76-410c-b977-f321a42f3e93.png)

