### PR TITLE
Update firestore index for testimony backfill

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -699,7 +699,12 @@
     {
       "collectionGroup": "publishedTestimony",
       "fieldPath": "court",
-      "indexes": [{ "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }]
+      "indexes": [
+        { "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" },
+        { "queryScope": "COLLECTION", "order": "ASCENDING" },
+        { "queryScope": "COLLECTION", "order": "DESCENDING" },
+        { "queryScope": "COLLECTION", "arrayConfig": "CONTAINS" }
+      ]
     }
   ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -694,5 +694,12 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    //// backfillTestimonyCounts ////
+    {
+      "collectionGroup": "publishedTestimony",
+      "fieldPath": "court",
+      "indexes": [{ "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }]
+    }
+  ]
 }


### PR DESCRIPTION
This was meant to be part of #546 . It also fixes #559 