### PR TITLE
Deflake integration tests

### DIFF
--- a/components/db/bills.test.ts
+++ b/components/db/bills.test.ts
@@ -73,9 +73,9 @@ describe("useBills", () => {
   })
 
   it("sorts by descending testimonyCount", async () => {
-    await setTestimonyCount("H1051", 40)
-    await setTestimonyCount("H1018", 20)
-    await setTestimonyCount("H1050", 10)
+    await setTestimonyCount("H1051", 400)
+    await setTestimonyCount("H1018", 200)
+    await setTestimonyCount("H1050", 100)
 
     const bills = await renderWithSort("testimonyCount")
 

--- a/components/db/testimony/useEditTestimony.test.ts
+++ b/components/db/testimony/useEditTestimony.test.ts
@@ -163,7 +163,10 @@ describe("useEditTestimony", () => {
 
     expect(result.current.draft?.publishedVersion).toBeDefined()
     await act(() => result.current.saveDraft.execute(updatedDraft))
-    expect(result.current.draft?.publishedVersion).toBeUndefined()
+    await waitFor(
+      () => expect(result.current.draft?.publishedVersion).toBeUndefined(),
+      { timeout: 5000 }
+    )
   })
 
   it("Deletes testimony", async () => {

--- a/components/db/useAsync.test.ts
+++ b/components/db/useAsync.test.ts
@@ -6,7 +6,8 @@ const callback1 = async () => 1
 const callback2 = async () => 2
 
 test("useAsync does not update when the callback changes", async () => {
-  const hook = renderHook((cb: any) => useAsync(cb, [cb]), {
+  // eslint-disable-next-line
+  const hook = renderHook((cb: any) => useAsync(cb, []), {
     initialProps: callback1
   })
 

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -12,13 +12,14 @@ import { testDb } from "../testUtils"
 // Backfill operation can take some time. Consider doing a partial backfil in
 // test.
 // TODO: Do a partial backfill or backfill a test collection
-const timeoutMs = 30000
+const timeoutMs = 50000
 jest.setTimeout(timeoutMs)
 
 const client = createClient()
 const testAlias = "bills"
-const mediumTimeout = { timeout: 5000, interval: 500 }
-const longTimeout = { timeout: 20000, interval: 500 }
+const mediumTimeout = { timeout: 5000, interval: 1000 }
+const reallyLongTimeout = { timeout: 40000, interval: 1000 }
+
 describe("Upgrades", () => {
   it("upgrades collections when schemas are missing", async () => {
     await clearAliases()
@@ -89,7 +90,7 @@ describe("Upgrades", () => {
         .retrieve()
       expect(alias.name).toBe(testAlias)
       expect(collection.num_documents).toBeGreaterThan(0)
-    }, longTimeout)
+    }, reallyLongTimeout)
     return alias!
   }
 })


### PR DESCRIPTION
To reduce test time further we can reduce scraper batch size when running on emulator (check with `process.env.FUNCTIONS_EMULATOR === "true"`). Adding some tests for the scrapers would be good too.
