### PR TITLE
639 add icons for bill sponsors and committee

### DIFF
--- a/components/bill/SponsorsAndCommittees.tsx
+++ b/components/bill/SponsorsAndCommittees.tsx
@@ -57,11 +57,16 @@ const Sponsors: FC<BillProps> = ({ bill, className }) => {
 
         {bill.content.Cosponsors.slice(0, 2).map(s => (
           <>
-            <LabeledIcon
-              idImage={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
-              mainText="Sponsor"
-              subText={s.Name} // can this be link? href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
-            />
+            {/* don't show lead sponsor again */}
+            {s.Id != primary.Id ? (
+              <LabeledIcon
+                idImage={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
+                mainText="Sponsor"
+                subText={s.Name} // can this be link? href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
+              />
+            ) : (
+              <></>
+            )}
           </>
         ))}
       </div>

--- a/components/bill/SponsorsAndCommittees.tsx
+++ b/components/bill/SponsorsAndCommittees.tsx
@@ -23,11 +23,10 @@ const Committees: FC<BillProps> = ({ bill }) => {
     <div>
       <div className="title">Committee</div>
       <div className="d-flex justify-content-around">
-        committee icon
-        <Item
-          label="Committee"
-          href={`https://malegislature.gov/Committees/Detail/${current.id}`}
-          name={current.name}
+        <LabeledIcon
+          idImage={`https://www.thefreedomtrail.org/sites/default/files/styles/image_width__720/public/content/slider-gallery/bulfinch_front.png?itok=kY2wLdnk`} // may want a better image or on our server
+          mainText="Committee"
+          subText={current.name} // can this be link? {`https://malegislature.gov/Committees/Detail/${current.id}`}
         />
       </div>
     </div>
@@ -49,33 +48,19 @@ const Sponsors: FC<BillProps> = ({ bill, className }) => {
           </Cosponsors>
         )}
       </div>
-      <div className="mt-2 mb-2 d-flex justify-content-around">
-        <Image
-          src={`https://malegislature.gov/Legislators/Profile/170/${primary.Id}.jpg`}
-          alt={`image of ${primary.Name}`}
-          roundedCircle
-          width="20"
-          height="20"
+      <div className="mt-2 mb-2 d-flex justify-content-right">
+        <LabeledIcon
+          idImage={`https://malegislature.gov/Legislators/Profile/170/${primary.Id}.jpg`}
+          mainText="Lead Sponsor"
+          subText={primary.Name} // can this be link? href={`https://malegislature.gov/Legislators/Profile/${primary.Id}`}
         />
-        <Item
-          label="Lead Sponsor"
-          href={`https://malegislature.gov/Legislators/Profile/${primary.Id}`}
-          name={primary.Name}
-        />
+
         {bill.content.Cosponsors.slice(0, 2).map(s => (
           <>
-            <Image
-              src={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
-              alt={`image of ${s.Name}`}
-              roundedCircle
-              width="20"
-              height="20"
-            />
-            <Item
-              key={s.Id}
-              label="Sponsor"
-              href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
-              name={s.Name}
+            <LabeledIcon
+              idImage={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
+              mainText="Sponsor"
+              subText={s.Name} // can this be link? href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
             />
           </>
         ))}

--- a/components/bill/SponsorsAndCommittees.tsx
+++ b/components/bill/SponsorsAndCommittees.tsx
@@ -1,9 +1,3 @@
-import {
-  FunctionComponent,
-  PropsWithChildren,
-  ReactElement,
-  ReactNode
-} from "react"
 import styled from "styled-components"
 import { Image } from "../bootstrap"
 import { BillProps } from "./types"
@@ -11,6 +5,7 @@ import { LabeledContainer } from "./LabeledContainer"
 import { External } from "../links"
 import { Cosponsors } from "./Cosponsors"
 import { FC } from "../types"
+import { LabeledIcon, TitledSectionCard } from "../shared"
 
 export const SponsorsAndCommittees: FC<BillProps> = ({ bill, className }) => {
   return (
@@ -28,6 +23,7 @@ const Committees: FC<BillProps> = ({ bill }) => {
     <div>
       <div className="title">Committee</div>
       <div className="d-flex justify-content-around">
+        committee icon
         <Item
           label="Committee"
           href={`https://malegislature.gov/Committees/Detail/${current.id}`}
@@ -54,18 +50,34 @@ const Sponsors: FC<BillProps> = ({ bill, className }) => {
         )}
       </div>
       <div className="mt-2 mb-2 d-flex justify-content-around">
+        <Image
+          src={`https://malegislature.gov/Legislators/Profile/170/${primary.Id}.jpg`}
+          alt={`image of ${primary.Name}`}
+          roundedCircle
+          width="20"
+          height="20"
+        />
         <Item
           label="Lead Sponsor"
           href={`https://malegislature.gov/Legislators/Profile/${primary.Id}`}
           name={primary.Name}
         />
         {bill.content.Cosponsors.slice(0, 2).map(s => (
-          <Item
-            key={s.Id}
-            label="Sponsor"
-            href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
-            name={s.Name}
-          />
+          <>
+            <Image
+              src={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
+              alt={`image of ${s.Name}`}
+              roundedCircle
+              width="20"
+              height="20"
+            />
+            <Item
+              key={s.Id}
+              label="Sponsor"
+              href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
+              name={s.Name}
+            />
+          </>
         ))}
       </div>
     </div>

--- a/components/bill/SponsorsAndCommittees.tsx
+++ b/components/bill/SponsorsAndCommittees.tsx
@@ -1,11 +1,9 @@
-import styled from "styled-components"
-import { Image } from "../bootstrap"
-import { BillProps } from "./types"
-import { LabeledContainer } from "./LabeledContainer"
 import { External } from "../links"
-import { Cosponsors } from "./Cosponsors"
+import { LabeledIcon } from "../shared"
 import { FC } from "../types"
-import { LabeledIcon, TitledSectionCard } from "../shared"
+import { Cosponsors } from "./Cosponsors"
+import { LabeledContainer } from "./LabeledContainer"
+import { BillProps } from "./types"
 
 export const SponsorsAndCommittees: FC<BillProps> = ({ bill, className }) => {
   return (
@@ -26,7 +24,13 @@ const Committees: FC<BillProps> = ({ bill }) => {
         <LabeledIcon
           idImage={`https://www.thefreedomtrail.org/sites/default/files/styles/image_width__720/public/content/slider-gallery/bulfinch_front.png?itok=kY2wLdnk`} // may want a better image or on our server
           mainText="Committee"
-          subText={current.name} // can this be link? {`https://malegislature.gov/Committees/Detail/${current.id}`}
+          subText={
+            <External
+              href={`https://malegislature.gov/Committees/Detail/${current.id}`}
+            >
+              {current.name}
+            </External>
+          }
         />
       </div>
     </div>
@@ -52,54 +56,32 @@ const Sponsors: FC<BillProps> = ({ bill, className }) => {
         <LabeledIcon
           idImage={`https://malegislature.gov/Legislators/Profile/170/${primary.Id}.jpg`}
           mainText="Lead Sponsor"
-          subText={primary.Name} // can this be link? href={`https://malegislature.gov/Legislators/Profile/${primary.Id}`}
+          subText={
+            <External
+              href={`https://malegislature.gov/Legislators/Profile/${primary.Id}`}
+            >
+              {primary.Name}
+            </External>
+          }
         />
 
-        {bill.content.Cosponsors.slice(0, 2).map(s => (
-          <>
-            {/* don't show lead sponsor again */}
-            {s.Id != primary.Id ? (
-              <LabeledIcon
-                idImage={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
-                mainText="Sponsor"
-                subText={s.Name} // can this be link? href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
-              />
-            ) : (
-              <></>
-            )}
-          </>
-        ))}
+        {bill.content.Cosponsors.filter(s => s.Id !== primary.Id)
+          .slice(0, 2)
+          .map(s => (
+            <LabeledIcon
+              key={s.Id}
+              idImage={`https://malegislature.gov/Legislators/Profile/170/${s.Id}.jpg`}
+              mainText="Sponsor"
+              subText={
+                <External
+                  href={`https://malegislature.gov/Legislators/Profile/${s.Id}`}
+                >
+                  {s.Name}
+                </External>
+              }
+            />
+          ))}
       </div>
     </div>
-  )
-}
-
-const Styled = {
-  Item: styled.div`
-    font-size: 0.75rem;
-    a {
-      color: var(--bs-blue);
-    }
-    .label {
-      font-weight: bold;
-    }
-    .content {
-      max-width: 15rem;
-    }
-  `
-}
-
-const Item: FC<{
-  label: string
-  name: string
-  href: string
-}> = ({ label, name, href, className }) => {
-  return (
-    <Styled.Item className={` ${className}`}>
-      <div className="label">{label}</div>
-      <div className="content">
-        <External href={href}>{name}</External>
-      </div>
-    </Styled.Item>
   )
 }

--- a/components/db/bills.ts
+++ b/components/db/bills.ts
@@ -22,6 +22,8 @@ export type { BillHistory } from "../../functions/src/bills/types"
 export type MemberReference = {
   Id: string
   Name: string
+  /**  1 = Legislative Member, 2 = Committee, 3 = Public Request, 4 = Special
+   * Request */
   Type: number
 }
 


### PR DESCRIPTION
See [Issue 639](https://github.com/codeforboston/advocacy-maps/issues/639)
May want to make Icon text into links.
May want to change the statehouse image.
Otherwise good.