### PR TITLE
Add a script to bulk-delete testimony

### DIFF
--- a/functions/src/testimony/deleteTestimony.ts
+++ b/functions/src/testimony/deleteTestimony.ts
@@ -16,10 +16,17 @@ export const deleteTestimony = https.onCall(async (data, context) => {
   const uid = checkAuth(context)
   const { publicationId } = checkRequest(DeleteTestimonyRequest, data)
 
+  return performDeleteTestimony(uid, publicationId)
+})
+
+export const performDeleteTestimony = async (
+  authorUid: string,
+  publicationId: string
+) => {
   let output: TransactionOutput
   try {
     output = await db.runTransaction(t =>
-      new DeleteTestimonyTransaction(t, publicationId, uid).run()
+      new DeleteTestimonyTransaction(t, publicationId, authorUid).run()
     )
   } catch (e) {
     logger.info("Deletion transaction failed.", e)
@@ -30,7 +37,7 @@ export const deleteTestimony = https.onCall(async (data, context) => {
   await attachments.applyDelete(output.attachmentId)
 
   return { deleted: output.deleted }
-})
+}
 
 type TransactionOutput = { deleted: boolean; attachmentId?: Maybe<string> }
 class DeleteTestimonyTransaction {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@react-aria/ssr": "^3.2.0",
     "@react-aria/utils": "^3.13.1",
     "@reduxjs/toolkit": "^1.8.3",
+    "@types/papaparse": "^5.3.5",
     "autolinker": "^3.16.0",
     "awesome-debounce-promise": "^2.1.0",
     "bootstrap": "5.1.3",

--- a/scripts/firebase-admin/batchDeleteTestimony.ts
+++ b/scripts/firebase-admin/batchDeleteTestimony.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "fs"
+import papa from "papaparse"
+import { Array, Literal, Optional, Record, String, Tuple } from "runtypes"
+import { performDeleteTestimony } from "../../functions/src/testimony"
+import { Script } from "./types"
+
+const Csv = Record({
+  data: Array(Record({ id: String, authorUid: String })),
+  // No Parse errors
+  errors: Tuple()
+})
+const Args = Record({
+  publicationsCsvPath: String,
+  force: Optional(Literal("true"))
+})
+
+/**
+ * yarn firebase-admin -e prod run-script batchDeleteTestimony --publicationsCsvPath=./prod-testimony.csv  --force true
+ */
+export const script: Script = async ({ args }) => {
+  const { publicationsCsvPath, force } = Args.check(args)
+  const csv = readFileSync(publicationsCsvPath, { encoding: "utf8" })
+  const publications = Csv.check(papa.parse(csv, { header: true })).data
+
+  if (!force) console.log("Dry run, specify --force true to delete")
+  for (const { authorUid, id } of publications) {
+    console.log(`Processing id ${id} author ${authorUid}`)
+    if (force) console.log(await performDeleteTestimony(authorUid, id))
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5532,6 +5532,13 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.4.tgz#30eb872153c7ead3e8688c476054ddca004115f6"
   integrity sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==
 
+"@types/papaparse@^5.3.5":
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.3.5.tgz#e5ad94b1fe98e2a8ea0b03284b83d2cb252bbf39"
+  integrity sha512-R1icl/hrJPFRpuYj9PVG03WBAlghJj4JW9Py5QdR8FFSxaLmZRyu7xYDCCBZIJNfUv3MYaeBbhBoX958mUTAaw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
I used this to clear out testimony in prod. First I listed all the testimony using the firebase-admin console, then produced the csv, then fed it into this script.