### PR TITLE
Updating copy for homepage training calendar link

### DIFF
--- a/components/HeroHeader/HeroHeader.js
+++ b/components/HeroHeader/HeroHeader.js
@@ -59,7 +59,7 @@ const HeroHeader = ({ authenticated }) => {
                   </div>
                   <p className={styles.subtitle}>{t("short_description")}</p>
                   <p>
-                    {t("newCommer")}? {t("checkout")}{" "}
+                    {t("newcomer")}{" "}
                     <a
                       href="https://calendar.google.com/calendar/embed?src=998f62323926f0b0076e7f578d3ca72b1bc94c4efa2f24be57b11f52b1b88595%40group.calendar.google.com&ctz=America%2FNew_York"
                       style={{ color: "white" }}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -12,10 +12,9 @@
     "followed" : "Followed"
   },
   "orgs": "Organizations",
-  "newCommer" : "New to MAPLE",
-  "checkout": "Check out",
+  "newcomer" : "New to MAPLE? For extra support, check",
   "calendar": "Our Calendar",
-  "joinTraining": "to see and join an upcoming training session!",
+  "joinTraining": "and join an upcoming training session!",
   "pending_upgrade_warning": {
     "header": "Organization Request In Progress",
     "content": "Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."


### PR DESCRIPTION
# Summary

This updates the copy for the homepage training calendar link for #1415 (so users don't feel that they *must* attend a training in order to use the site). Closes #1415 

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

Old Copy:

<img width="543" alt="Old Copy 1415" src="https://github.com/codeforboston/maple/assets/2694761/4bc50a1d-e94e-4286-bca7-bd84757c7f21">


New Copy:
<img width="535" alt="New Copy 1415" src="https://github.com/codeforboston/maple/assets/2694761/3fbdd305-4975-436f-9dc9-e72ca0e367a1">

# Known issues

None

# Steps to test/reproduce

1. Go to the home page
1. Observe the changed copy
