### PR TITLE
Make Profiles Source of Truth for Notification Settings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,4 @@ dist
 coverage
 storybook-static
 llm
+playwright-report

--- a/components/db/profile/types.ts
+++ b/components/db/profile/types.ts
@@ -23,7 +23,7 @@ export const SOCIAL_NETWORKS = [
 ] as const
 
 export type SocialLinks = Partial<
-  Record<typeof SOCIAL_NETWORKS[number], string>
+  Record<(typeof SOCIAL_NETWORKS)[number], string>
 >
 
 export type Profile = {

--- a/components/db/profile/types.ts
+++ b/components/db/profile/types.ts
@@ -23,7 +23,7 @@ export const SOCIAL_NETWORKS = [
 ] as const
 
 export type SocialLinks = Partial<
-  Record<(typeof SOCIAL_NETWORKS)[number], string>
+  Record<typeof SOCIAL_NETWORKS[number], string>
 >
 
 export type Profile = {
@@ -35,6 +35,7 @@ export type Profile = {
   senator?: ProfileMember
   public?: boolean
   notificationFrequency?: Frequency
+  nextDigestAt?: FirebaseFirestore.Timestamp
   about?: string
   social?: SocialLinks
   profileImage?: string

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,6 +29,11 @@ service cloud.firestore {
       function doesNotChangeRole() { 
         return !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role'])
       }
+      function doesNotChangeNextDigestAt() {
+        // Only admins/automatic processes should be able to change the
+        // email digest notification times
+        return !request.resource.data.diff(resource.data).affectedKeys().hasAny(['nextDigestAt'])
+      }
       // either the change doesn't include the public field, 
       // or the user is a base user (i.e. not an org)
       function validPublicChange() {
@@ -47,7 +52,7 @@ service cloud.firestore {
 
       // Allow users to make updates except to delete their profile or set the role field.
       // Only admins can delete a user profile or set the user role field. 
-      allow update: if validUser() && doesNotChangeRole() && validPublicChange()
+      allow update: if validUser() && doesNotChangeRole() && validPublicChange() && doesNotChangeNextDigestAt()
     }
     // Allow querying publications individually or with a collection group.
     match /{path=**}/publishedTestimony/{id} {

--- a/functions/src/notifications/deliverNotifications.ts
+++ b/functions/src/notifications/deliverNotifications.ts
@@ -5,7 +5,7 @@ import * as fs from "fs"
 import { Timestamp } from "../firebase"
 import { getNextDigestAt, getNotificationStartDate } from "./helpers"
 import { startOfDay } from "date-fns"
-import { TestimonySubmissionNotificationFields } from "./types"
+import { TestimonySubmissionNotificationFields, Profile } from "./types"
 import {
   BillDigest,
   NotificationEmailDigest,
@@ -15,7 +15,6 @@ import {
 import { prepareHandlebars } from "../email/handlebarsHelpers"
 import { getAuth } from "firebase-admin/auth"
 import { Frequency } from "../auth/types"
-import { Profile } from "../../../components/db/profile/types"
 
 const NUM_BILLS_TO_DISPLAY = 4
 const NUM_USERS_TO_DISPLAY = 4
@@ -51,8 +50,8 @@ const deliverEmailNotifications = async () => {
     .get()
 
   const emailPromises = profilesSnapshot.docs.map(async profileDoc => {
-    const user = profileDoc.data() as Profile
-    if (!user || !user.notificationFrequency) {
+    const profile = profileDoc.data() as Profile
+    if (!profile || !profile.notificationFrequency) {
       console.log(
         `User ${profileDoc.id} has no notificationFrequency - skipping`
       )
@@ -70,7 +69,7 @@ const deliverEmailNotifications = async () => {
     const digestData = await buildDigestData(
       profileDoc.id,
       now,
-      user.notificationFrequency
+      profile.notificationFrequency
     )
 
     // If there are no new notifications, don't send an email
@@ -98,7 +97,7 @@ const deliverEmailNotifications = async () => {
       console.log(`Saved email message to user ${profileDoc.id}`)
     }
 
-    const nextDigestAt = getNextDigestAt(user.notificationFrequency)
+    const nextDigestAt = getNextDigestAt(profile.notificationFrequency)
     await profileDoc.ref.update({ nextDigestAt })
 
     console.log(`Updated nextDigestAt for ${profileDoc.id} to ${nextDigestAt}`)

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -1,3 +1,4 @@
+import { Frequency } from "../auth/types"
 import { BillHistory } from "../bills/types"
 import { Timestamp } from "../firebase"
 
@@ -61,4 +62,9 @@ export interface BillHistoryUpdateNotificationFields {
     delivered: boolean
   }
   createdAt: FirebaseFirestore.Timestamp
+}
+
+export interface Profile {
+  notificationFrequency?: Frequency
+  nextDigestAt?: FirebaseFirestore.Timestamp
 }

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -1,13 +1,5 @@
-import { Frequency } from "../auth/types"
 import { BillHistory } from "../bills/types"
 import { Timestamp } from "../firebase"
-
-// This should probably live somewhere else once other code starts caring about this
-export interface User {
-  email?: string
-  notificationFrequency?: Frequency
-  nextDigestAt?: Timestamp
-}
 
 export interface Notification {
   type: string

--- a/functions/src/notifications/updateUserNotificationFrequency.ts
+++ b/functions/src/notifications/updateUserNotificationFrequency.ts
@@ -35,14 +35,13 @@ export const updateUserNotificationFrequency = functions.firestore
         return null
       }
 
-      // Update user document in the 'users' collection
+      // Update the profile document to include the computed `nextDigestAt`
       await admin
         .firestore()
-        .collection("users")
+        .collection("profiles")
         .doc(userId)
         .set(
           {
-            notificationFrequency: notificationFrequency,
             nextDigestAt: getNextDigestAt(notificationFrequency)
           },
           { merge: true }

--- a/scripts/firebase-admin/backfillNextDigestAt.ts
+++ b/scripts/firebase-admin/backfillNextDigestAt.ts
@@ -1,0 +1,49 @@
+/*
+    This script is intended to backfill the `nextDigestAt` field
+    into the `profiles` collection. This field is used to determine
+    when the next notifications digest email should be sent to a user
+    based on their set `notificationFrequency`.
+
+    This script can be safely removed after the `nextDigestAt` field
+    has been added to the profiles collection.
+*/
+
+import { getNextDigestAt } from "../../functions/src/notifications/helpers"
+import { Profile } from "../../components/db/profile/types"
+import { Script } from "./types"
+import { Boolean, Record } from "runtypes"
+
+// todo - actually move nextDigestAt into profiles
+// - no reason not to do it now, we have the backfill and the rules
+//  don't protect any collection
+// I'll need to fix the rules so that writes to the `profiles::nextDigestAt` field can only be made by admins
+//  - e.g. this script, the deliverNotifcaitons script, or theupdateNotifiaciotn script
+const Args = Record({
+  dryRun: Boolean
+})
+
+export const script: Script = async ({ db, auth, args }) => {
+  const profilesSnapshot = await db.collection("profiles").get()
+
+  const updatePromises = profilesSnapshot.docs.map(async profileDoc => {
+    const profile = profileDoc.data() as Profile
+
+    if (profile.notificationFrequency) {
+      const nextDigestAt = getNextDigestAt(profile.notificationFrequency)
+
+      if (!args.dryRun) {
+        await profileDoc.ref.update({ nextDigestAt })
+      }
+      console.log(
+        `Updated nextDigestAt for ${profileDoc.id} to ${nextDigestAt}`
+      )
+    } else {
+      console.log(
+        `Profile ${profileDoc.id} does not have notificationFrequency - skipping`
+      )
+    }
+  })
+
+  await Promise.all(updatePromises)
+  console.log("Backfill complete")
+}

--- a/scripts/firebase-admin/backfillNextDigestAt.ts
+++ b/scripts/firebase-admin/backfillNextDigestAt.ts
@@ -13,11 +13,6 @@ import { Profile } from "../../components/db/profile/types"
 import { Script } from "./types"
 import { Boolean, Record } from "runtypes"
 
-// todo - actually move nextDigestAt into profiles
-// - no reason not to do it now, we have the backfill and the rules
-//  don't protect any collection
-// I'll need to fix the rules so that writes to the `profiles::nextDigestAt` field can only be made by admins
-//  - e.g. this script, the deliverNotifcaitons script, or theupdateNotifiaciotn script
 const Args = Record({
   dryRun: Boolean
 })

--- a/scripts/firebase-admin/backfillNotificationFrequency.ts
+++ b/scripts/firebase-admin/backfillNotificationFrequency.ts
@@ -1,3 +1,6 @@
+// DEPRECATED - This will no longer be useful after we've moved notificationFrequency to profiles
+// This should no longer be run and will be removed in a future update
+
 import { Script } from "./types"
 import { listAllUsers } from "./list-all-users"
 
@@ -9,7 +12,7 @@ export const script: Script = async ({ db, auth }) => {
 
   for (const user of allUsers) {
     // Get user document from Firestore
-    const userDoc = db.collection("users").doc(user.uid)
+    const userDoc = db.collection("profiles").doc(user.uid)
     const doc = await userDoc.get()
 
     // If the user document exists in Firestore

--- a/scripts/firebase-admin/backfillUserEmails.ts
+++ b/scripts/firebase-admin/backfillUserEmails.ts
@@ -1,3 +1,8 @@
+// DEPRECATED - This will no longer be useful going forward
+//              We plan to rely on the `profiles` collection for casual email use
+//              and the firebase-auth API where we need verified email addresses
+// This should no longer be run and will be removed in a future update
+
 import { UserRecord } from "firebase-admin/auth"
 import { Auth } from "functions/src/types"
 import { Script } from "./types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6369,15 +6369,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
-caniuse-lite@^1.0.30001406:
-  version "1.0.30001568"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001568.tgz#53fa9297273c9a977a560663f48cbea1767518b7"
-  integrity sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==
-
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001572"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz#1ccf7dc92d2ee2f92ed3a54e11b7b4a3041acfa0"
-  integrity sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==
+caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001565:
+  version "1.0.30001700"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz"
+  integrity sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==
 
 cardinal@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
# Summary

This PR finally addresses an issue we talked about at a previous hack night regarding `profiles` vs `users` - having both of these collections with duplicated fields synced between them felt fragile, so this PR makes `profiles` the canonical and only source of truth for `notificationFrequency` and `nextDigestAt`. 

I only deprecated the old user-related scripts here while this rolls out - they should be safe to delete post-V2, but they're explicitly called out in the Docker setup and I figured we can wait a minute to mess with that.

# Deploy Checklist
- [ ] Run the new backfill script against DEV and PROD (in dryRun mode first for safety)

# Screenshots

N/A

# Known issues

* I think there's still some potential weird edge cases here if users update their own notificationFrequency repeatedly in quick succession - I don't think that's a big enough deal or likely enough case to dig into before launch, but it's worth keeping an eye out on this count.
