### PR TITLE
Disabling i18next rules on the admin page 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,5 +24,17 @@
     ],
     // TODO: Fix existing warnings and make them errors going forward
     "i18next/no-literal-string": "warn"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "components/moderation/**/*.js",
+        "components/moderation/**/*.ts",
+        "components/moderation/**/*.tsx"
+      ],
+      "rules": {
+        "i18next/no-literal-string": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
# Summary

We only really expect that to be used by English speakers for the foreseeable future - not worth even the minimal effort to actually migrate this to use translations.