### PR TITLE
Cold Start Workaround 

### DIFF
--- a/functions/.env
+++ b/functions/.env
@@ -1,1 +1,2 @@
 TYPESENSE_API_URL=https://o89yhjf824.execute-api.us-east-1.amazonaws.com/search
+APP_URL_BASE=https://maple-dev.vercel.app

--- a/functions/.env.digital-testimony-prod
+++ b/functions/.env.digital-testimony-prod
@@ -1,1 +1,2 @@
 TYPESENSE_API_URL=https://yyd73lsw3h.execute-api.us-east-1.amazonaws.com/search
+APP_URL_BASE=https://mapletestimony.org

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -50,6 +50,8 @@ export {
 
 export { transcription } from "./webhooks"
 
+export { pingVercel } from "./keepwarm"
+
 export * from "./triggerPubsubFunction"
 
 // Export the health check last so it is loaded last.

--- a/functions/src/keepwarm/index.ts
+++ b/functions/src/keepwarm/index.ts
@@ -1,0 +1,1 @@
+export * from "./pingVercel"

--- a/functions/src/keepwarm/pingVercel.ts
+++ b/functions/src/keepwarm/pingVercel.ts
@@ -1,0 +1,39 @@
+import axios from "axios"
+import * as functions from "firebase-functions"
+
+/**
+ * Pings Vercel every 5 minutes to keep the serverless functions warm.
+ *
+ * We need this to avoid painful cold starts for users
+ * when loading bill/testimony details in the app.
+ *
+ * Vercel only keeps a function warm for 10 minutes by default,
+ * so pinging the site every 5 minutes should keep it warm indefinitely.
+ *
+ * There are options we can configure in Vercel so we don't
+ * need this hacky workaround, but this should suffice until
+ * we regain access to the Vercel dashboard.
+ *
+ * TODO: Remove this once we've updated our Vercel config
+ */
+
+export const pingVercel = functions.pubsub
+  .schedule("every 5 minutes")
+  .onRun(async () => {
+    // We can use the same court/bill on both environments
+    // because the source data is the same
+    const urlToPing = `${process.env.APP_URL_BASE}/bills/194/H868`
+    console.log(`Pinging ${urlToPing}...`)
+
+    try {
+      const start = Date.now()
+      const response = await axios.get(urlToPing, {
+        timeout: 30_000
+      })
+      const end = Date.now()
+
+      console.log(`Ping successful: ${response.status} - Took ${end - start}ms`)
+    } catch (e) {
+      console.error("Ping failed:", e)
+    }
+  })


### PR DESCRIPTION
# Summary

This PR adds a new firebase function to ping the site once every 5 minutes as a hacky workaround to keep the Vercel serverless functions warm. Vercel keeps functions warm for 10 minutes after the cold start, so this should help us mitigate the painful cold starts until we're able to actually adjust the Vercel settings.