### PR TITLE
feat(truncate): Truncate text on the Newsfeed card to 600 characters

### DIFF
--- a/components/NewsfeedCard/NewsfeedCardBody.tsx
+++ b/components/NewsfeedCard/NewsfeedCardBody.tsx
@@ -3,6 +3,7 @@ import CardBootstrap from "react-bootstrap/Card"
 import { useMediaQuery } from "usehooks-ts"
 import { Col, Row } from "../bootstrap"
 import { Internal } from "components/links"
+import { truncateText } from "components/formatting"
 
 interface NewsfeedCardBodyProps {
   billText?: string
@@ -33,7 +34,7 @@ export const NewsfeedBillCardBody = (props: NewsfeedCardBodyProps) => {
                 className={`m-3`}
               />
               <CardBootstrap.Text className={`mb-0 mt-2`}>
-                <strong>{text}</strong>
+                <strong>{truncateText(text, 600)}</strong>
               </CardBootstrap.Text>
               <>
                 {t("newsfeed.actionTaken")}
@@ -52,7 +53,7 @@ export const NewsfeedBillCardBody = (props: NewsfeedCardBodyProps) => {
             />
             <Col className={`m-2`}>
               <CardBootstrap.Text className={`mb-0`}>
-                <strong>{text}</strong>
+                <strong>{truncateText(text, 600)}</strong>
               </CardBootstrap.Text>
               <>
                 {t("newsfeed.actionTaken")}
@@ -112,7 +113,10 @@ export const NewsfeedTestimonyCardBody = (props: NewsfeedCardBodyProps) => {
                   </>
                 )}
               </div>
-              <strong className={`mb-4`}>{`"${text}"`}</strong>
+              <strong className={`mb-4`}>{`"${truncateText(
+                text,
+                600
+              )}"`}</strong>
             </Col>
           ) : (
             <>
@@ -138,7 +142,10 @@ export const NewsfeedTestimonyCardBody = (props: NewsfeedCardBodyProps) => {
               <Col
                 className={`d-flex align-self-center justify-content-center`}
               >
-                <strong className={`m-4`}>{`"${text}"`}</strong>
+                <strong className={`m-4`}>{`"${truncateText(
+                  text,
+                  600
+                )}"`}</strong>
               </Col>
             </>
           )}

--- a/components/formatting.tsx
+++ b/components/formatting.tsx
@@ -65,3 +65,6 @@ export const decodeHtmlCharCodes = (s: string) =>
   s.replace(/(&#(\d+);)/g, (match, capture, charCode) =>
     String.fromCharCode(charCode)
   )
+
+export const truncateText = (s: string | undefined, maxLength: number) =>
+  !!s && s.length > maxLength ? s.substring(0, maxLength) + "..." : s


### PR DESCRIPTION
# Summary

This PR truncates text on the Newsfeed cards to 600 characters at most - this should make the newsfeed easier to navigate when dealing with long testimonies.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

<img width="693" alt="Screenshot 2025-03-26 at 11 45 25 PM" src="https://github.com/user-attachments/assets/b78019cd-b1ca-40c0-ba46-bbae310080f7" />


# Known issues

N/A

# Steps to test/reproduce

1. Go to the Newsfeed page
2. Scroll down to any testimony longer than 600 characters and see that it is truncated down to 600 characters