### PR TITLE
Add hyperlinks to SmartTags on Bill Details page

### DIFF
--- a/components/bill/Summary.tsx
+++ b/components/bill/Summary.tsx
@@ -8,6 +8,8 @@ import { SmartDisclaimer } from "./SmartDisclaimer"
 import { SmartIcon } from "./SmartIcon"
 import { TestimonyCounts } from "./TestimonyCounts"
 import { BillProps } from "./types"
+import { currentGeneralCourt } from "functions/src/shared"
+import { BillTopic } from "functions/src/bills/types"
 
 const SummaryContainer = styled(Container)`
   background-color: white;
@@ -49,17 +51,21 @@ const SmartTagButton = styled.button`
   font-size: 12px;
 `
 
-const SmartTag = ({ icon, tagName }: { icon: String; tagName: String }) => {
+const SmartTag = ({ topic }: { topic: BillTopic }) => {
   return (
-    <SmartTagButton
-      className={`btn btn-secondary d-flex text-nowrap mt-1 mx-1 p-1`}
+    <links.Internal
+      href={links.billSearchByTopicLink(currentGeneralCourt, topic)}
     >
-      &nbsp;
-      <SmartIcon icon={icon} />
-      &nbsp;
-      {tagName}
-      &nbsp;
-    </SmartTagButton>
+      <SmartTagButton
+        className={`btn btn-secondary d-flex text-nowrap mt-1 mx-1 p-1`}
+      >
+        &nbsp;
+        <SmartIcon icon={topic.category} />
+        &nbsp;
+        {topic.topic}
+        &nbsp;
+      </SmartTagButton>
+    </links.Internal>
   )
 }
 
@@ -134,7 +140,7 @@ export const Summary = ({
           <Row className="mx-1 mb-3">{bill.summary}</Row>
           <Row className={`d-flex mx-0 my-1`} xs="auto">
             {bill.topics?.map(t => (
-              <SmartTag key={t.topic} icon={t.category} tagName={t.topic} />
+              <SmartTag key={t.topic} topic={t} />
             ))}
           </Row>
         </>

--- a/components/links.tsx
+++ b/components/links.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { forwardRef, PropsWithChildren } from "react"
-import { CurrentCommittee } from "../functions/src/bills/types"
+import { BillTopic, CurrentCommittee } from "../functions/src/bills/types"
 import { Testimony } from "components/db/testimony"
 import { Bill, MemberContent } from "./db"
 import { formatBillId } from "./formatting"
@@ -129,4 +129,12 @@ export const twitterShareLink = (publication: Testimony, t: TFunction) => {
     tweetUrl = `https://twitter.com/intent/tweet?text=${tweet}`
 
   return tweetUrl
+}
+
+export const billSearchByTopicLink = (court: number, topic: BillTopic) => {
+  const params = {
+    "bills/sort/latestTestimonyAt:desc[multiselectHierarchicalMenu][topics.lvl1][0]": `${topic.category} > ${topic.topic}`,
+    "bills/sort/latestTestimonyAt:desc[refinementList][court][0]": `${court}`
+  }
+  return `/bills?${new URLSearchParams(params).toString()}`
 }


### PR DESCRIPTION


# Summary

This PR adds hyperlinks to the topic SmartTags on the Bill Details page. They will now link to the Bill Search page with the appropriate topic filter applied automatically.

This resolves https://github.com/codeforboston/maple/issues/1772

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

The Topic Filter list doesn't currently scroll down to make the selected topic visible on navigation (even though the filter is applied correctly and the green tag will appear above the search results). I don't feel this is a blocker on getting this out, but it would be a slightly nicer UX, so potentially a good follow-up issue.

# Steps to test/reproduce
1. Go to a Bill Details page
2. Click on one of the topic Smart Tags 
3. Verify that you're redirected to the Bill Search page with the previously selected 