### PR TITLE
TESTING - DONT MERGE: Adding timing to test page load stuff

### DIFF
--- a/components/firebase.ts
+++ b/components/firebase.ts
@@ -87,7 +87,7 @@ const timedInitializeFirestore = () => {
 
 export const firestore = initialized
   ? timedGetFirestore()
-  : timedInitializeFirestore
+  : timedInitializeFirestore()
 export const auth = getAuth()
 export const storage = getStorage()
 export const functions = getFunctions()

--- a/components/firebase.ts
+++ b/components/firebase.ts
@@ -67,11 +67,27 @@ export const { Provider } = createService(() => {
   }, [])
 })
 
+const timedGetFirestore = () => {
+  const start = performance.now()
+  const firestore = getFirestore()
+  const end = performance.now()
+  console.log("Getting firestore took", end - start, "ms")
+  return firestore
+}
+
+const timedInitializeFirestore = () => {
+  const start = performance.now()
+  const firestore = initializeFirestore(app, {
+    ignoreUndefinedProperties: true
+  })
+  const end = performance.now()
+  console.log("Initializing firestore took", end - start, "ms")
+  return firestore
+}
+
 export const firestore = initialized
-  ? getFirestore()
-  : initializeFirestore(app, {
-      ignoreUndefinedProperties: true
-    })
+  ? timedGetFirestore()
+  : timedInitializeFirestore
 export const auth = getAuth()
 export const storage = getStorage()
 export const functions = getFunctions()

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/bills/[court]/[billId].tsx
+++ b/pages/bills/[court]/[billId].tsx
@@ -31,18 +31,38 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
 
   const query = Query.safeParse(ctx.query)
   if (!query.success) return { notFound: true }
-  const bill = await dbService().getBill(query.data)
+
+  const dbsStart = performance.now()
+  const dbs = dbService()
+  const dbsEnd = performance.now()
+  console.log("Getting dbService took", dbsEnd - dbsStart, "ms")
+
+  const billStart = performance.now()
+  const bill = await dbs.getBill(query.data)
+  const billEnd = performance.now()
+  console.log("Getting bill took", billEnd - billStart, "ms")
+
   if (!bill) return { notFound: true }
+
+  const translationsStart = performance.now()
+  const translations = await serverSideTranslations(locale, [
+    "auth",
+    "common",
+    "footer",
+    "testimony",
+    "profile"
+  ])
+  const translationsEnd = performance.now()
+  console.log(
+    "Getting translations took",
+    translationsEnd - translationsStart,
+    "ms"
+  )
+
   return {
     props: {
       bill: JSON.parse(JSON.stringify(bill)),
-      ...(await serverSideTranslations(locale, [
-        "auth",
-        "common",
-        "footer",
-        "testimony",
-        "profile"
-      ]))
+      ...translations
     }
   }
 }


### PR DESCRIPTION
DO NOT MERGE - Just curious about how this bill details DB stuff hits on actual Vercel-hosted pages. 

Given that this won't hit the "production" version of the dev site, I don't think this can take advantage of the Fluid Compute or bytecode caching I was trying, but it may help narrow down the source of our cold start slowness.
