### PR TITLE
Update setup-node version

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: "yarn"


### PR DESCRIPTION
Updating setup-node version from 2 to 4 to fix the build - version 2 uses another action that was just decommissioned, so we need to update.

See https://github.com/actions/setup-node/issues/1275#issuecomment-2788204086 for more details on the issue