### PR TITLE
Fix EditProfile Link in Signup Flow

### DIFF
--- a/components/auth/VerifyEmailModal.tsx
+++ b/components/auth/VerifyEmailModal.tsx
@@ -19,7 +19,7 @@ export default function VerifyEmailModal({
             <Image fluid height={`18em`} src="/mailbox.svg" alt="" />
             <h2 className={`fw-bold`}>{t("verifyEmail")}</h2>
             <h6>{t("verifyLinkSent")}</h6>
-            <Internal href="/editprofile" className="view-edit-profile">
+            <Internal href="/edit-profile" className="view-edit-profile">
               <Button onClick={onHide}>{t("setUpProfile")}</Button>
             </Internal>
           </Stack>

--- a/pages/edit-profile/[[...docName]].tsx
+++ b/pages/edit-profile/[[...docName]].tsx
@@ -25,7 +25,8 @@ export const getStaticPaths: GetStaticPaths = async ctx => {
     paths: [
       { params: { docName: ["about-you"] } },
       { params: { docName: ["testimonies"] } },
-      { params: { docName: ["following"] } }
+      { params: { docName: ["following"] } },
+      { params: { docName: [] } }
     ],
     fallback: false
   }


### PR DESCRIPTION
# Summary

We were still using the old `editprofile` link in the signup flow, so new users were getting 404s at the end of the flow when they go to edit their profile.

This PR:
* Updates the signup flow's old editprofile link to the new edit-profile url in the Signup flow
* Makes `edit-profile/` an optional catchall so navigating to the root will default to the about-you tab

# Steps to test/reproduce

1. Go to the home page
2. Signup as a new org
3. Follow the link to "Edit Profile" at the end of the signup flow
4. Verify that it successfully takes you to the signup page.
