### PR TITLE
Fixing pagination for Bill Details testimonies

### DIFF
--- a/components/TestimonyCard/ViewTestimony.tsx
+++ b/components/TestimonyCard/ViewTestimony.tsx
@@ -143,10 +143,7 @@ const ViewTestimony = (
                   ))}
 
                 {(pagination.hasPreviousPage || pagination.hasNextPage) && (
-                  <PaginationButtons
-                    pagination={pagination}
-                    totalItems={totalTestimonies}
-                  />
+                  <PaginationButtons pagination={pagination} />
                 )}
               </div>
             ) : (

--- a/components/table/PaginationButtons.tsx
+++ b/components/table/PaginationButtons.tsx
@@ -1,6 +1,4 @@
 import {
-  faAngleLeft,
-  faAngleRight,
   faAngleDoubleLeft,
   faAngleDoubleRight
 } from "@fortawesome/free-solid-svg-icons"
@@ -16,20 +14,12 @@ export const PaginationButtons = ({
     nextPage,
     hasNextPage,
     previousPage,
-    hasPreviousPage,
-    itemsPerPage
-  },
-  totalItems
+    hasPreviousPage
+  }
 }: {
   pagination: Pagination
-  totalItems: number | undefined
 }) => {
   const { t } = useTranslation("common")
-
-  if (totalItems === undefined) {
-    return null
-  }
-  let currentPageEnd = Math.min(currentPage * itemsPerPage, totalItems)
 
   return (
     <div className="d-flex justify-content-center my-3">
@@ -43,23 +33,13 @@ export const PaginationButtons = ({
       <SpanStyle variant="secondary" className="align-self-center">
         {t("table.page", { currentPage })}
       </SpanStyle>
-      <NextStyle
-        variant="secondary"
-        onClick={nextPage}
-        disabled={!hasNextPage || currentPageEnd >= totalItems}
-      >
+      <NextStyle variant="secondary" onClick={nextPage} disabled={!hasNextPage}>
         <FontAwesomeIcon icon={faAngleDoubleRight} />
       </NextStyle>
     </div>
   )
 }
 
-const SetPageStyle = styled(Button)`
-  font-family: nunito;
-  background-color: #1a3185;
-  margin: 2px;
-  border-radius: 0;
-`
 const SpanStyle = styled(Button)`
   background-color: #1a3185;
   color: white;


### PR DESCRIPTION
# Summary

At some point, we introduced a dependency on the total number of testimonies, which is only available on the Profile page's version of this component (because it requires an additional query) and is not necessary for any rendering. This PR removes that unneeded dependency so that the pagination buttons work as expected on both the Bill Details and Profile page testimony lists.

Resolves #1771 

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Go to a Bill Details page for a bill with more than 10 testimonies
1. Confirm that the testimony pagination renders and works as expected
