### PR TITLE
Fix Send Test Email Script

### DIFF
--- a/scripts/firebase-admin/sendTestEmail.ts
+++ b/scripts/firebase-admin/sendTestEmail.ts
@@ -62,7 +62,7 @@ const renderToHtmlString = (digestData: NotificationEmailDigest) => {
     "utf8"
   )
   const compiledTemplate = handlebars.compile(templateSource)
-  return compiledTemplate({ digestData })
+  return compiledTemplate(digestData)
 }
 
 // Summary of Bills


### PR DESCRIPTION
# Summary

This PR removes unneeded parens around the digest data object in sendTestEmail script - it was preventing the handlebars template from picking up the values and causing "Invalid Date" errors when we tried to send the email.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce
1. Send a test email - see that the date renders correctly
