### PR TITLE
Auth Fix for Email Notifications

### DIFF
--- a/functions/src/notifications/deliverNotifications.ts
+++ b/functions/src/notifications/deliverNotifications.ts
@@ -1,8 +1,7 @@
 import * as functions from "firebase-functions"
-import * as admin from "firebase-admin"
 import * as handlebars from "handlebars"
 import * as fs from "fs"
-import { Timestamp } from "../firebase"
+import { auth, db, Timestamp } from "../firebase"
 import { getNextDigestAt, getNotificationStartDate } from "./helpers"
 import { startOfDay } from "date-fns"
 import { TestimonySubmissionNotificationFields, Profile } from "./types"
@@ -13,7 +12,6 @@ import {
   UserDigest
 } from "./emailTypes"
 import { prepareHandlebars } from "../email/handlebarsHelpers"
-import { getAuth } from "firebase-admin/auth"
 import { Frequency } from "../auth/types"
 
 const NUM_BILLS_TO_DISPLAY = 4
@@ -21,9 +19,6 @@ const NUM_USERS_TO_DISPLAY = 4
 const NUM_TESTIMONIES_TO_DISPLAY = 6
 const EMAIL_TEMPLATE_PATH = "../email/digestEmail.handlebars"
 
-// Get a reference to the Firestore database
-const db = admin.firestore()
-const auth = getAuth()
 const path = require("path")
 
 const getVerifiedUserEmail = async (uid: string) => {
@@ -103,7 +98,9 @@ const deliverEmailNotifications = async () => {
     batch.update(profileDoc.ref, { nextDigestAt })
     await batch.commit()
 
-    console.log(`Updated nextDigestAt for ${profileDoc.id} to ${nextDigestAt}`)
+    console.log(
+      `Updated nextDigestAt for ${profileDoc.id} to ${nextDigestAt?.toDate()}`
+    )
   })
 
   // Wait for all email documents to be created


### PR DESCRIPTION
# Summary

We've been getting credential-related firebase auth errors in the `deliverNotifications` function. Looks like we weren't using the properly initialized firebase auth instance - this PR just switches over to that.

# Screenshots

N/A

# Known issues

The bug doesn't replicate locally due to how our credential auth for local dev is setup - so this is part educated guess.

# Steps to test/reproduce

N/A

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
