### PR TITLE
Fix Bill Links on Following Tab

### DIFF
--- a/components/EditProfilePage/FollowingTabComponents.tsx
+++ b/components/EditProfilePage/FollowingTabComponents.tsx
@@ -124,7 +124,7 @@ export function FollowedItem({
       <Row className={`align-items-center flex-column flex-md-row`}>
         {isBillElement(element) ? (
           <>
-            <Internal href={`bills/${element.court}/${element.billId}`}>
+            <Internal href={`/bills/${element.court}/${element.billId}`}>
               {formatBillId(element.billId)}
             </Internal>
             <Col xs={12} md={8} className={`d-flex`}>


### PR DESCRIPTION
# Summary

This PR fixes the links to individual bill pages in the Following Tab of the user profile. 

For whatever reason, those links were getting rendered as `/edit-profile/bills/[billId]` (which doesn't exist) - I've updated to ensure they get rendered as `/bills/[billId]`.

# Checklist
- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Go to the Following Tab of your user profile
2. Click on the Name (e.g. H1000) of a bill you follow
3. Confirm that it navigates you to the individual bill page without a 404
