### PR TITLE
Temporarily Disable pendingUpgrade flow for organizations

### DIFF
--- a/functions/src/profile/finishSignup.ts
+++ b/functions/src/profile/finishSignup.ts
@@ -14,13 +14,17 @@ export const finishSignup = functions.https.onCall(async (data, context) => {
 
   const { requestedRole } = checkRequestZod(CreateProfileRequest, data)
 
-  let role: Role = "user"
+  let role: Role = requestedRole
 
   // Only an admin can approve organizations, after they've signed up initially
   // There's a nextjs api route: PATCH /users/<uid> {"role": <role>}
-  if (requestedRole === "organization") {
-    role = "pendingUpgrade"
-  }
+
+  // Removing the "pendingUpgrade" flow  (temporarily) because the
+  // organization approval process is currently  too cumbersome.
+
+  // if (requestedRole === "organization") {
+  //   role = "pendingUpgrade"
+  // }
 
   await setRole({ role, auth, db, uid })
 


### PR DESCRIPTION
# Summary

Per discussion with Matt V, this PR temporarily disables the `pendingUpgrade` flow for organization signups (it was proving too cumbersome for the value it provides). Note that this won't knock any organizations who are currently in the `pendingUpgrade` flow out of that flow - we'll still need to clear the queue one more time after this goes live.

Not ripping it out entirely since I suspect we'll re-introduce it at some point - possibly after the initial onboarding wave or before we introduce an org-exclusive feature.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

It might be worth marking the profiles that went through the upgrade approval process vs those that haven't - I didn't bother since we should already be able to figure that out by using the time this change goes live as a dividing line, but I'm open to being talked into it.

## Test Plan
1. In a private window, create a new account as an Org user
2. Navigate to the user profile and confirm that there is no "pendingUpgrade" banner

1. In a private window, create a new account as a regular User (just to confirm the normal flow still works)
