### PR TITLE
Increase Hearing Scraper Timeout

### DIFF
--- a/functions/src/events/scrapeEvents.ts
+++ b/functions/src/events/scrapeEvents.ts
@@ -263,7 +263,7 @@ const shouldScrapeVideo = async (EventId: number) => {
 
 class HearingScraper extends EventScraper<HearingListItem, Hearing> {
   constructor() {
-    super("every 60 minutes", 240)
+    super("every 60 minutes", 480)
   }
 
   async listEvents() {


### PR DESCRIPTION
# Summary
Increase hearing scraper timeout to 8 minutes

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

N/A