### PR TITLE
Use Profile Email Instead of Firebase Auth

### DIFF
--- a/functions/src/notifications/deliverNotifications.ts
+++ b/functions/src/notifications/deliverNotifications.ts
@@ -232,6 +232,7 @@ const renderToHtmlString = (digestData: NotificationEmailDigest) => {
 // Firebase Functions
 export const deliverNotifications = functions.pubsub
   .schedule("47 9 1 * 2") // 9:47 AM on the first day of the month and on Tuesdays
+  .timeZone("America/New_York")
   .onRun(deliverEmailNotifications)
 
 export const httpsDeliverNotifications = functions.https.onRequest(

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -65,6 +65,7 @@ export interface BillHistoryUpdateNotificationFields {
 }
 
 export interface Profile {
+  email?: string
   notificationFrequency?: Frequency
   nextDigestAt?: FirebaseFirestore.Timestamp
 }


### PR DESCRIPTION
This PR switches the email address we send a user's notifications to over to pulling from the Firestore `profiles` collection instead of the Firebase Auth service. 

This sidesteps the obnoxious auth issues we've been having and should unblock the rollout. 

The main disadvantage is we lose the ability to check if an email is verified before sending (because that only lives in the Auth service and there's not a documented event to listen to for update propagation into Firestore), but I'm not sure how much longer it will take to untangle whatever is going on with our opaque permissions setup and the risk is capped by SendGrid's bounce management anyway.