### PR TITLE
Update Firestore Rules for Transcriptions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -89,5 +89,16 @@ service cloud.firestore {
         allow read, write: if request.auth.token.get("role", "user") == "admin"
       }
     }
+    match /transcriptions/{tid} {
+      // public, read-only
+      allow read: if true
+      allow write: if false
+      
+      // public, read-only
+      match /utterances/{uid} {
+        allow read: if true
+        allow write: if false
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR updates our  Firestore rules to allow public reads of transcriptions and utterances. This data should all be publically accessible anyway, and making this change now will help for the user testing for the Transcriptions UI that we're doing with https://github.com/codeforboston/maple/pull/1749

