### PR TITLE
Switch email image links to the mapletestimony.org domain

### DIFF
--- a/functions/src/email/digestEmail.handlebars
+++ b/functions/src/email/digestEmail.handlebars
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Digest Email</title>
-    <link rel="stylesheet" type="text/css" href="email/style.css" />
+    <link rel="stylesheet" type="text/css" href="https://mapletestimony.org/email/style.css" />
   </head>
 
   <body style="background: white; width: 600px; min-height: 80vh; font-family: 'Nunito';

--- a/functions/src/email/partials/bills/bill.handlebars
+++ b/functions/src/email/partials/bills/bill.handlebars
@@ -22,14 +22,11 @@
     <div style="height: 19px; font-weight: 700; font-size: 14px; line-height: 100%;
                 color: #000000; margin: auto; padding: 16px 0px 26px 0px;
                 text-align: center">
-      <img src="email\images_no-svgs\endorse.png" alt="checkmark" style="padding-right: 18px"/>
-      {{!-- replace with link to mapletestimony.org when going live --}}
+      <img src="https://mapletestimony.org/email/images_no-svgs/endorse.png" alt="checkmark" style="padding-right: 18px"/>
       {{this.endorseCount}} Endorse 
-      <img src="email\images_no-svgs\neutral.png" alt="dash" style="padding: 0 18px"/>
-      {{!-- replace with link to mapletestimony.org when going live --}}
+      <img src="https://mapletestimony.org/email/images_no-svgs/neutral.png" alt="dash" style="padding: 0 18px"/>
       {{this.neutralCount}} Neutral 
-      <img src="email\images_no-svgs\oppose.png" alt="x-mark" style="padding: 0 18px"/>
-      {{!-- replace with link to mapletestimony.org when going live --}}
+      <img src="https://mapletestimony.org/email/images_no-svgs/oppose.png" alt="x-mark" style="padding: 0 18px"/>
       {{this.opposeCount}} Oppose
     </div>
   </div>

--- a/functions/src/email/partials/newsFeedLink.handlebars
+++ b/functions/src/email/partials/newsFeedLink.handlebars
@@ -13,7 +13,7 @@
          target="_blank"
          rel="noopener noreferrer"
       >
-        <img src="email\images_no-svgs\newspaper.png" alt="" />
+        <img src="https://mapletestimony.org/email/images_no-svgs/newspaper.png" alt="" />
         Newsfeed
       </a>
     </p>

--- a/functions/src/email/partials/users/user.handlebars
+++ b/functions/src/email/partials/users/user.handlebars
@@ -36,7 +36,7 @@
           </td>
           <td style="width: 75px">
             <img
-              src="email\images_no-svgs\\{{this.bills.0.position}}.jpg"
+              src="https://mapletestimony.org/email/images_no-svgs/{{this.bills.0.position}}.jpg"
             />
           </td>
         {{/if}}
@@ -51,7 +51,7 @@
           </td>
           <td style="width: 75px">
             <img
-              src="email\images_no-svgs\\{{this.bills.1.position}}.jpg"
+              src="https://mapletestimony.org/email/images_no-svgs/{{this.bills.1.position}}.jpg"
             />
           </td>
         {{/if}}
@@ -67,7 +67,7 @@
           </td>
           <td style="width: 75px">
             <img
-              src="email\images_no-svgs\\{{this.bills.2.position}}.jpg"
+              src="https://mapletestimony.org/email/images_no-svgs/{{this.bills.2.position}}.jpg"
             />
           </td>
         {{/if}}
@@ -82,7 +82,7 @@
           </td>
           <td style="width: 75px">
             <img
-              src="email\images_no-svgs\\{{this.bills.3.position}}.jpg"
+              src="https://mapletestimony.org/email/images_no-svgs/{{this.bills.3.position}}.jpg"
             />
           </td>
         {{/if}}
@@ -99,7 +99,7 @@
           </td>
           <td style="width: 75px">
             <img
-              src="email\images_no-svgs\\{{this.bills.4.position}}.jpg"
+              src="https://mapletestimony.org/email/images_no-svgs/{{this.bills.4.position}}.jpg"
             />
           </td>
         {{/if}}
@@ -126,7 +126,7 @@
             </td>
             <td style="width: 75px">
               <img
-                src="email\images_no-svgs\\{{this.bills.5.position}}.jpg"
+                src="https://mapletestimony.org/email/images_no-svgs/{{this.bills.5.position}}.jpg"
               />
             </td>
           {{/if}}


### PR DESCRIPTION
# Summary

This PR switches the image links in the notification emails to point to the real deployed `mapletestimony.org`. Ideally, the domain here should be configurable based on env for local development and testing on the dev site, but let's fix one problem at a time.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

N/A