### PR TITLE
Add proactive video-prop saving

### DIFF
--- a/functions/src/events/scrapeEvents.ts
+++ b/functions/src/events/scrapeEvents.ts
@@ -316,6 +316,15 @@ class HearingScraper extends EventScraper<HearingListItem, Hearing> {
             EventId
           })
 
+          // Immediately save video info to prevent reprocessing
+          // since the bulkWriter does not save the video properties
+          // returned from this method.
+          await db.collection("events").doc(`hearing-${EventId}`).update({
+            videoURL: maybeVideoUrl,
+            videoFetchedAt: Timestamp.now(),
+            videoTranscriptionId: transcriptId
+          })
+
           return {
             id: `hearing-${EventId}`,
             type: "hearing",


### PR DESCRIPTION
The bulkWriter int he EventScraper run method doesn't seem to be saving the video props passed to it from HearingScraper. This pr proactively saves those props inside the HearingScraper getEvent method.