### PR TITLE
Bump memory for hearings scraper up to 4GB

### DIFF
--- a/functions/src/events/scrapeEvents.ts
+++ b/functions/src/events/scrapeEvents.ts
@@ -1,4 +1,4 @@
-import { runWith } from "firebase-functions"
+import { RuntimeOptions, runWith } from "firebase-functions"
 import { DateTime } from "luxon"
 import { JSDOM } from "jsdom"
 import { AssemblyAI } from "assemblyai"
@@ -25,17 +25,23 @@ import fs from "fs"
 abstract class EventScraper<ListItem, Event extends BaseEvent> {
   private schedule
   private timeout
+  private memory
 
-  constructor(schedule: string, timeout: number) {
+  constructor(
+    schedule: string,
+    timeout: number,
+    memory: RuntimeOptions["memory"] = "256MB"
+  ) {
     this.schedule = schedule
     this.timeout = timeout
+    this.memory = memory
   }
 
   get function() {
     return runWith({
       timeoutSeconds: this.timeout,
       secrets: ["ASSEMBLY_API_KEY"],
-      memory: "2GB"
+      memory: this.memory
     })
       .pubsub.schedule(this.schedule)
       .onRun(() => this.run())
@@ -293,7 +299,7 @@ const shouldScrapeVideo = async (EventId: number) => {
 
 class HearingScraper extends EventScraper<HearingListItem, Hearing> {
   constructor() {
-    super("every 60 minutes", 480)
+    super("every 60 minutes", 480, "4GB")
   }
 
   async listEvents() {


### PR DESCRIPTION
# Summary

This PR bumps the memory for the HearingsScraper up to 4GB (at 2GB, we're running out of memory processing larger videos). IMO it *shouldn't* require that much, but it's not a huge lift and it solves our immediate problem - could be worth digging into more down the road.

Also dropping the memory for the other scrapers back down to 256MB - they're not doing any video processing, so they don't need the extra juice.

Worth noting that we should consider kicking these video processing tasks off into a separate task queue - they're currently very slow, so if we get more than one new hearing video per job run, the function will likely timeout. This isn't the end of the world functionality wise (we'll eventually catch up within a few hours given the current hearing dataset), but is certainly sub-optimal.