### PR TITLE
Only deploy functions:maple (i.e. TypeScript) from github actions

### DIFF
--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build and Deploy to Firebase
         uses: w9jds/firebase-action@v13.0.2
         with:
-          args: deploy --force --only firestore,functions,storage
+          args: deploy --force --only firestore,functions:maple,storage
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           ASSEMBLY_API_KEY: ${{ secrets.ASSEMBLY_API_KEY }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build and Deploy to Firebase
         uses: w9jds/firebase-action@v13.0.2
         with:
-          args: deploy --force --only firestore,functions,storage
+          args: deploy --force --only firestore,functions:maple,storage
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           ASSEMBLY_API_KEY: ${{ secrets.ASSEMBLY_API_KEY }}


### PR DESCRIPTION
# Summary

Failure here https://github.com/codeforboston/maple/actions/runs/16610951399/job/46993784937 is because we aren't yet ready to deploy the python functions in CI. For now, only deploy the typescript functions i.e. `functions:maple`

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
