### PR TITLE
extract text to translation ready files -- Communicating with Legislators page

### DIFF
--- a/components/CommunicatingWithLegislators/CommunicatingWithLegislatorsContent.tsx
+++ b/components/CommunicatingWithLegislators/CommunicatingWithLegislatorsContent.tsx
@@ -1,6 +1,7 @@
 import { Row, Col } from "../bootstrap"
 import Image from "react-bootstrap/Image"
 import styled from "styled-components"
+import { useTranslation } from "next-i18next"
 
 const StyledImage = styled(Image)`
   width: 12.5rem;
@@ -27,9 +28,9 @@ const WritingContent = () => (
   <Row className="align-items-center">
     <Col xs={12} md={8} lg={{ span: 7, offset: 1 }}>
       <p>
-        You can submit your thoughts on a bill to the Committee hearing it
-        before the date of their public hearing. This website, the MAPLE
-        platform, focuses on this mechanism.
+        {useTranslation("learnComponents").t(
+          "communicating.testifyInWriting.content"
+        )}
       </p>
     </Col>
     <Col md={4} lg={3}>
@@ -58,8 +59,9 @@ const OralContent = () => (
       lg={{ span: 7, order: 1 }}
     >
       <p>
-        You can attend a public hearing for a bill of interest to you and sign
-        up for a slot to speak before the Committee.
+        {useTranslation("learnComponents").t(
+          "communicating.testifyOrally.content"
+        )}
       </p>
     </Col>
   </Row>
@@ -69,12 +71,9 @@ const WriteOrCallContent = () => (
   <Row className="align-items-center">
     <Col xs={12} md={8} lg={{ span: 7, offset: 1 }}>
       <p>
-        You can contact your legislators any time by looking up their contact
-        information on the MA Legislature website. Your voice will probably
-        carry the most weight with the House and Senate representatives of your
-        own district, but you are free to contact Committee Chairs or any other
-        member of the legislature with your opinions. You could request a
-        meeting in person.
+        {useTranslation("learnComponents").t(
+          "communicating.writeOrCall.content"
+        )}
       </p>
     </Col>
     <Col md={4} lg={3}>

--- a/components/LearnTestimonyComponents/LearnComponents.tsx
+++ b/components/LearnTestimonyComponents/LearnComponents.tsx
@@ -181,15 +181,15 @@ const CommunicatingWithLegislators = () => {
           </h1>
           <p className={"ms-1 fs-4"}>{t("communicating.intro")}</p>
 
-          <CommWithLegCard title={t("communicating.testifyInWriting")}>
+          <CommWithLegCard title={t("communicating.testifyInWriting.title")}>
             <WritingContent />
           </CommWithLegCard>
 
-          <CommWithLegCard title={t("communicating.testifyOrally")}>
+          <CommWithLegCard title={t("communicating.testifyOrally.title")}>
             <OralContent />
           </CommWithLegCard>
 
-          <CommWithLegCard title={t("communicating.writeOrCall")}>
+          <CommWithLegCard title={t("communicating.writeOrCall.title")}>
             <WriteOrCallContent />
           </CommWithLegCard>
         </Col>

--- a/public/locales/en/learnComponents.json
+++ b/public/locales/en/learnComponents.json
@@ -83,9 +83,18 @@
   "communicating": {
     "title": "Communicating with Legislators",
     "intro": "There are multiple ways to share your perspective and knowledge with your legislators.",
-    "testifyInWriting": "Testify in writing",
-    "testifyOrally": "Testify orally",
-    "writeOrCall": "Write or call them"
+    "testifyInWriting": {
+      "title": "Testify in writing",
+      "content": "You can submit your thoughts on a bill to the Committee hearing it before the date of their public hearing. This website, the MAPLE platform, focuses on this mechanism."
+    },
+    "testifyOrally": {
+      "title": "Testify orally",
+      "content": "You can attend a public hearing for a bill of interest to you and sign up for a slot to speak before the Committee."
+    },
+    "writeOrCall": {
+      "title": "Write or call them",
+      "content": "You can contact your legislators any time by looking up their contact information on the MA Legislature website. Your voice will probably carry the most weight with the House and Senate representatives of your own district, but you are free to contact Committee Chairs or any other member of the legislature with your opinions. You could request a meeting in person."
+    }
   },
   "legislative": {
     "title": "Understanding the Massachusetts Legislative Process",


### PR DESCRIPTION
# Summary

* Extracts literal strings to translation-ready files for all text related to the Learn - Communicating with Legislators page.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

Left side is current website, right side is this branch. No unintended changes.

<img width="1439" height="836" alt="Screenshot 2025-07-30 at 4 59 33 PM" src="https://github.com/user-attachments/assets/f978c03d-3abc-496d-9ecc-270ae92afc65" />

# Steps to test/reproduce

1. Go to localhost:3000/learn/communicating-with-legislators and confirm the page looks the same as usual