### PR TITLE
Update Newsletter Link

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -11,6 +11,7 @@ import CustomDropdown, {
   CustomDropdownProps
 } from "components/Footer/CustomFooterDropdown"
 import { FooterContainer } from "./FooterContainer"
+import { NEWSLETTER_SIGNUP_URL } from "components/common"
 
 export type PageFooterProps = {
   children?: any
@@ -282,7 +283,7 @@ const PageFooter = (props: PageFooterProps) => {
           {t("legal.disclaimer")}
           {" - "}
           <a
-            href="https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337"
+            href={NEWSLETTER_SIGNUP_URL}
             style={{ color: "white" }}
             target="_blank"
             rel="noopener noreferrer"

--- a/components/HeroHeader/HeroHeader.js
+++ b/components/HeroHeader/HeroHeader.js
@@ -6,6 +6,7 @@ import ScrollTrackingItem from "../ScrollTrackEffect/ScrollTrackerItem"
 import styles from "./HeroHeader.module.css"
 import { useTranslation } from "next-i18next"
 import { capitalize } from "lodash"
+import { NEWSLETTER_SIGNUP_URL, TRAINING_CALENDAR_URL } from "../common"
 
 const HeroHeader = ({ authenticated }) => {
   const { t } = useTranslation("common")
@@ -59,7 +60,7 @@ const HeroHeader = ({ authenticated }) => {
                   <p>
                     {t("newcomer")}{" "}
                     <a
-                      href="https://calendar.google.com/calendar/embed?src=998f62323926f0b0076e7f578d3ca72b1bc94c4efa2f24be57b11f52b1b88595%40group.calendar.google.com&ctz=America%2FNew_York"
+                      href={TRAINING_CALENDAR_URL}
                       style={{ color: "white" }}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -70,7 +71,7 @@ const HeroHeader = ({ authenticated }) => {
                   </p>
                   <p>
                     <a
-                      href="https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337"
+                      href={NEWSLETTER_SIGNUP_URL}
                       style={{ color: "white" }}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/components/auth/TermsOfServiceModal.tsx
+++ b/components/auth/TermsOfServiceModal.tsx
@@ -3,6 +3,7 @@ import { Button, Col, Modal, Row, Stack } from "../bootstrap"
 import { External } from "components/links"
 import { NavLink } from "../Navlink"
 import { useTranslation } from "next-i18next"
+import { NEWSLETTER_SIGNUP_URL } from "components/common"
 
 export default function TermsOfServiceModal({
   show,
@@ -80,7 +81,7 @@ export default function TermsOfServiceModal({
               </Row>
               <Row>
                 <NavLink
-                  href="https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337"
+                  href={NEWSLETTER_SIGNUP_URL}
                   other={{
                     className: `text-center fs-5 mt-4 text-secondary`,
                     target: "_blank",

--- a/components/common.tsx
+++ b/components/common.tsx
@@ -1,0 +1,4 @@
+export const NEWSLETTER_SIGNUP_URL =
+  "https://cdn.forms-content.sg-form.com/66e4c174-72e5-11f0-847b-fe4d8dd139cf"
+export const TRAINING_CALENDAR_URL =
+  "https://calendar.google.com/calendar/embed?src=998f62323926f0b0076e7f578d3ca72b1bc94c4efa2f24be57b11f52b1b88595%40group.calendar.google.com&ctz=America%2FNew_York"


### PR DESCRIPTION
# Summary

This PR updates the newsletter signup form link to the new URL (since SendGrid changed their tier limits on us again).

@jicruz96 Borrowing your changes from https://github.com/codeforboston/maple/pull/1881 for this - We just wanted this out immediately so we're ready when the Op-Ed drops so I opened a separate PR with the real link.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Go to the home page
1. Click the "Newsletter" link in the Hero Header and see that it navigates to the signup form
1. Click the "Newsletter" link in the Footer and see that it navigates to the signup form
