### PR TITLE
Fallback to publicEmail for Org Users in Email notifications

### DIFF
--- a/functions/src/notifications/deliverNotifications.ts
+++ b/functions/src/notifications/deliverNotifications.ts
@@ -66,7 +66,7 @@ const deliverEmailNotifications = async () => {
     }
 
     // Temporarily using email from the profile to test the non-auth issues
-    const verifiedEmail = profile.email //await getVerifiedUserEmail(profileDoc.id)
+    const verifiedEmail = profile.email || profile.contactInfo?.publicEmail //await getVerifiedUserEmail(profileDoc.id)
     if (!verifiedEmail) {
       console.log(
         `Skipping user ${profileDoc.id} because they have no verified email address`

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -68,4 +68,7 @@ export interface Profile {
   email?: string
   notificationFrequency?: Frequency
   nextDigestAt?: FirebaseFirestore.Timestamp
+  contactInfo?: {
+    publicEmail?: string
+  }
 }


### PR DESCRIPTION
# Summary

When we added email addresses to profiles, we handled the process differently for Organizations - putting it under the `contactInfo` field's `publicEmail`

We should probably consolidate this at some point, but this will help enable email notifications for our organization power users (and this will all be a moot point once we fix the Firebase Auth bug).

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

N/A
