### PR TITLE
Make Default Notification Frequency "Weekly"

### DIFF
--- a/components/EditProfilePage/ProfileSettingsModal.tsx
+++ b/components/EditProfilePage/ProfileSettingsModal.tsx
@@ -82,7 +82,7 @@ export default function ProfileSettingsModal({
 
   const handleToggleNotifications = async () => {
     if (notifications === "None") {
-      setNotifications("Monthly")
+      setNotifications("Weekly")
     } else {
       setNotifications("None")
     }

--- a/components/Newsfeed/Newsfeed.tsx
+++ b/components/Newsfeed/Newsfeed.tsx
@@ -144,16 +144,14 @@ export default function Newsfeed() {
     const [settingsModal, setSettingsModal] = useState<"show" | null>(null)
     const [notifications, setNotifications] = useState<
       "Weekly" | "Monthly" | "None"
-    >(notificationFrequency ? notificationFrequency : "Monthly")
+    >(notificationFrequency ? notificationFrequency : "Weekly")
     const [isProfilePublic, setIsProfilePublic] = useState<false | true>(
       isPublic ? isPublic : false
     )
 
     const onSettingsModalOpen = () => {
       setSettingsModal("show")
-      setNotifications(
-        notificationFrequency ? notificationFrequency : "Monthly"
-      )
+      setNotifications(notificationFrequency ? notificationFrequency : "Weekly")
       setIsProfilePublic(isPublic ? isPublic : false)
     }
 

--- a/components/auth/hooks.ts
+++ b/components/auth/hooks.ts
@@ -76,7 +76,7 @@ export function useCreateUserWithEmailAndPassword(isOrg: boolean) {
           setProfile(credentials.user.uid, {
             fullName,
             orgCategories: categories,
-            notificationFrequency: "Monthly",
+            notificationFrequency: "Weekly",
             email: credentials.user.email
           }),
           sendEmailVerification(credentials.user)
@@ -85,7 +85,7 @@ export function useCreateUserWithEmailAndPassword(isOrg: boolean) {
         await Promise.all([
           setProfile(credentials.user.uid, {
             fullName,
-            notificationFrequency: "Monthly",
+            notificationFrequency: "Weekly",
             email: credentials.user.email,
             public: true
           }),
@@ -136,7 +136,7 @@ export function useSignInWithPopUp() {
       await Promise.all([
         setProfile(credentials.user.uid, {
           fullName: credentials.user.displayName ?? "New User",
-          notificationFrequency: "Monthly",
+          notificationFrequency: "Weekly",
           email: credentials.user.email,
           public: true
         })


### PR DESCRIPTION
# Summary

This PR makes the default notification frequency for new users "Weekly" (instead of the current "Monthly"). This applies for all new users, and also applies as the default when users re-enable disabled notifications in the Settings modal.

This does not cover the backfill for these settings, which we plan to do soon (pending resolution of the Firebase Auth email issue).

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Signup for a new account
2. Check that the account's notificationFrequency is "Weekly" in the settings modal of the Profile/Newsfeed.
