### PR TITLE
Update Firestore Rules for Transcription Paragraphs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -99,6 +99,12 @@ service cloud.firestore {
         allow read: if true
         allow write: if false
       }
+
+      // public, read-only
+      match /paragraphs/{pid} {
+        allow read: if true
+        allow write: if false
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

This PR allows read-only access to the `paragraphs` subcollection of `transcriptions` - we'll need this to render the front-end of the Hearing Transcription UI.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

N/A