### PR TITLE
Backfill Script for Weekly Email Notifications

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/scripts/firebase-admin/backfillWeeklyFrequency.ts
+++ b/scripts/firebase-admin/backfillWeeklyFrequency.ts
@@ -1,0 +1,43 @@
+import { Script } from "./types"
+
+const BATCH_SIZE = 100
+
+export const script: Script = async ({ db }) => {
+  console.log("Setting notificationFrequency to Weekly for all users")
+  let numProfilesUpdated = 0
+  let numProfilesSkipped = 0
+
+  let profiles = await db.collection("profiles").limit(BATCH_SIZE).get()
+
+  do {
+    const lastDoc = profiles.docs[profiles.docs.length - 1]
+
+    const batch = db.batch()
+    for (const doc of profiles.docs) {
+      if (doc.data().notificationFrequency === "None") {
+        // Preserve "None" settings (since these may be intentional opt-outs)
+        numProfilesSkipped++
+        console.log(
+          `Skipping user ${doc.id} with notification frequency set to None.`
+        )
+      } else {
+        numProfilesUpdated++
+        batch.update(doc.ref, { notificationFrequency: "Weekly" })
+        console.log(`Updating user ${doc.id} notification frequency to Weekly.`)
+      }
+    }
+
+    numProfilesUpdated += profiles.docs.length
+    await batch.commit()
+
+    profiles = await db
+      .collection("profiles")
+      .startAfter(lastDoc)
+      .limit(BATCH_SIZE)
+      .get()
+  } while (profiles.docs.length > 0)
+
+  console.log(
+    `Finished updating notification frequency. Updated ${numProfilesUpdated} profiles, skipped ${numProfilesSkipped} profiles.`
+  )
+}


### PR DESCRIPTION


# Summary

This PR adds a backfill script that will set the `notificationFrequency` of email notifications to `Weekly` for all users who haven't explicitly opted out already (of which there are only 3 on PROD).

This pairs with the recent decision to make `Weekly` the default notification frequency for new users - this script will simply update our current users (the vast majority of whom are on the default settings) to match that.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

I'm starting to become disenchanted with our local-first method for running one-off scripts like this - we should ideally be deploying something to e.g. Google Cloud Run to make these more transferable, better documented/logged, and less prone to local environment/auth issues. I don't think it's worth investing that effort here, but this is officially on my radar (and may be worth tackling with a more involved migration script - perhaps the Transcription one).

# Steps to test/reproduce

N/A
