### PR TITLE
Re-Enabling VerifiedEmail Fetch

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
I want this for better debugging in the deployed environments (For reference, I have not been able to reproduce the Firebase Auth bug we've been dealing with here locally). This will fall back to the current email behavior if the fetch fails (as we expect), so it should be safe.