### PR TITLE
fix: swap arrow icons

### DIFF
--- a/components/HearingsScheduled/HearingsScheduled.tsx
+++ b/components/HearingsScheduled/HearingsScheduled.tsx
@@ -219,8 +219,8 @@ export const HearingsScheduled = () => {
               wrap={false}
               activeIndex={monthIndex}
               onSelect={handleSelect}
-              prevIcon={<CarouselControlNextIcon aria-hidden="true" />}
-              nextIcon={<CarouselControlPrevIcon aria-hidden="true" />}
+              prevIcon={<CarouselControlPrevIcon aria-hidden="true" />}
+              nextIcon={<CarouselControlNextIcon aria-hidden="true" />}
             >
               {monthsList?.map(month => {
                 return (


### PR DESCRIPTION
# Summary

Fix arrows in `HearingsScheduled.tsx` by swapping icons.

Closes #1920

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

<img width="1393" height="577" alt="image" src="https://github.com/user-attachments/assets/f50d230e-e4d5-40a3-a3f3-8cc7a75257ce" />

# Known issues

None

# Steps to test/reproduce

1. Go to home page (`/`)
2. Scroll to "Hearings Scheduled" section.
3. Add hard-coded events, if necessary. The arrows will not be visible if there are no events to show.
4. See the arrows now fixed.
5. Test on mobile view to ensure the arrows are also fixed.
