### PR TITLE
Adding Daily option to notification settings dropdown

### DIFF
--- a/components/EditProfilePage/ProfileSettingsModal.tsx
+++ b/components/EditProfilePage/ProfileSettingsModal.tsx
@@ -146,6 +146,9 @@ export default function ProfileSettingsModal({
                     variant="outline-secondary"
                   />
                   <Dropdown.Menu className={`col-12 bg-white `}>
+                    <Dropdown.Item onClick={() => setNotifications("Daily")}>
+                      {t("email.daily")}
+                    </Dropdown.Item>
                     <Dropdown.Item onClick={() => setNotifications("Weekly")}>
                       {t("email.weekly")}
                     </Dropdown.Item>


### PR DESCRIPTION
# Summary

Looks like we missed a spot in the Daily notification work - this should be the last piece needed to roll out the Daily frequency option that was recently added to the backend.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.
- [n/a] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce
1. Go to the edit profile page
2. Open the settings modal
3. Verify that you can select "Daily" as a frequency option