### PR TITLE
Use setup-firebase instead of the old one

### DIFF
--- a/.github/workflows/deploy-python-backend-dev.yml
+++ b/.github/workflows/deploy-python-backend-dev.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           python-version: "3.11"
       - name: Build and deploy to Firebase
-        uses: w9jds/setup-firebase@main
+        # The only tag on this repo is v1.0.0, but it is very old
+        # This SHA is main as of 2025-10-21
+        uses: w9jds/setup-firebase@869785322147e6a53d463a55db0a5af1b4ce4ba6
         with:
           tools-version: 13.8.0
       - run: firebase deploy --force --only functions:maple-llm


### PR DESCRIPTION
# Summary

In theory, this is the maintained version of setup-firebase by the same author. This gets us out of docker land and should allow us to use `setup-python` and `setup-node` directly without all this nonsense.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
