### PR TITLE
Debugging broken browse-bills and testimony playwright tests

### DIFF
--- a/tests/e2e/browse-bills.spec.ts
+++ b/tests/e2e/browse-bills.spec.ts
@@ -5,23 +5,21 @@ test.beforeEach(async ({ page }) => {
   const billpage = new BillPage(page)
   await billpage.goto()
   await billpage.removePresetCourtfilter()
-
- 
 })
 
 test.describe("Search result test", () => {
   test("should search for bills", async ({ page }) => {
-    const billpage = new BillPage(page);
+    const billpage = new BillPage(page)
 
-    const searchTerm = billpage.searchWord;
-    
-    await billpage.search(searchTerm);
-    
-    await expect(billpage.queryFilter).toBeVisible();
-    
-    await expect(billpage.queryFilter).toContainText(searchTerm);
+    const searchTerm = billpage.searchWord
 
-    await expect(billpage.firstBill).toBeVisible();
+    await billpage.search(searchTerm)
+
+    await expect(billpage.queryFilter).toBeVisible()
+
+    await expect(billpage.queryFilter).toContainText(searchTerm)
+
+    await expect(billpage.firstBill).toBeVisible()
   })
 
   test("should show search query", async ({ page }) => {

--- a/tests/e2e/page_objects/billPage.ts
+++ b/tests/e2e/page_objects/billPage.ts
@@ -14,7 +14,6 @@ export class BillPage {
   readonly billPageBackToList: Locator
   readonly resultsCountText: Locator
 
-
   constructor(page: Page) {
     this.page = page
     this.searchWord = "health"
@@ -29,22 +28,20 @@ export class BillPage {
     this.currentCategorySelector = ".ais-CurrentRefinements-item"
     this.basicCategorySelector = "div.ais-RefinementList.mb-4"
     this.resultsCountText = page.getByText("Results").first()
-
   }
 
   async goto() {
     await this.page.goto("http://localhost:3000/bills")
-    await this.resultCount.waitFor({ state: 'visible', timeout: 30000 });    
-// await this.page.waitForSelector("li.ais-Hits-item a",{timeout:90000})
-    
+    await this.resultCount.waitFor({ state: "visible", timeout: 30000 })
+    // await this.page.waitForSelector("li.ais-Hits-item a",{timeout:90000})
   }
 
   async search(query: string) {
-    await this.searchBar.focus();
+    await this.searchBar.focus()
     await this.searchBar.fill(query)
-    const activeQueryFilter = this.page.getByText(`Query: ${query}`).first(); 
-    
-    await activeQueryFilter.waitFor({ state: 'visible', timeout: 50000 });
+    const activeQueryFilter = this.page.getByText(`Query: ${query}`).first()
+
+    await activeQueryFilter.waitFor({ state: "visible", timeout: 50000 })
   }
 
   async sort(option: string) {
@@ -154,15 +151,17 @@ export class BillPage {
 
     return filterLabel
   }
-  
-  async removePresetCourtfilter() {
-    const activeCourtCheckbox = this.page 
-        .locator('div, span, label', { has: this.page.getByText(/Court/i) })
-        .getByRole('checkbox', { checked: true });
-    
-    await activeCourtCheckbox.click({ noWaitAfter: true, timeout: 0 });
 
-    await this.page.getByText("Results").first().waitFor({ state: 'visible', timeout: 60000 });
-    
+  async removePresetCourtfilter() {
+    const activeCourtCheckbox = this.page
+      .locator("div, span, label", { has: this.page.getByText(/Court/i) })
+      .getByRole("checkbox", { checked: true })
+
+    await activeCourtCheckbox.click({ noWaitAfter: true, timeout: 0 })
+
+    await this.page
+      .getByText("Results")
+      .first()
+      .waitFor({ state: "visible", timeout: 60000 })
   }
 }

--- a/tests/e2e/page_objects/testimony.ts
+++ b/tests/e2e/page_objects/testimony.ts
@@ -39,18 +39,20 @@ export class TestimonyPage {
 
   async sort(option: string) {
     // previoud code: await this.page.getByText("Sort by New -> Old").click()
-    await this.page.getByText(/Sort by/i).first().click();
+    await this.page
+      .getByText(/Sort by/i)
+      .first()
+      .click()
     await this.page.getByRole("option", { name: option }).click()
   }
 
   async removePresetCourtfilter() {
-    const activeCourtCheckbox = this.page 
-        .locator('div, span, label', { has: this.page.getByText(/Court/i) })
-        .getByRole('checkbox', { checked: true });
-    
-    await activeCourtCheckbox.click({ noWaitAfter: true, timeout: 0 });
+    const activeCourtCheckbox = this.page
+      .locator("div, span, label", { has: this.page.getByText(/Court/i) })
+      .getByRole("checkbox", { checked: true })
 
-    await this.resultsCountText.waitFor({ state: 'visible', timeout: 60000 });
-    
+    await activeCourtCheckbox.click({ noWaitAfter: true, timeout: 0 })
+
+    await this.resultsCountText.waitFor({ state: "visible", timeout: 60000 })
   }
 }

--- a/tests/e2e/testimony.spec.ts
+++ b/tests/e2e/testimony.spec.ts
@@ -103,32 +103,32 @@ test.describe("Testimony Filtering", () => {
   })
 
   test("should filter by position: endorse", async ({ page }) => {
-    const testimonyPage = new TestimonyPage(page);
-    testimonyPage.removePresetCourtfilter();
-    
-    const endorseCheckbox = page.getByRole("checkbox", { name: /endorse/i }); 
-    await endorseCheckbox.check({ timeout: 30000 });
-    
-    await expect(testimonyPage.positionFilterItem).toContainText("endorse");
-    await expect(page).toHaveURL(/.*position%5D%5B0%5D=endorse/);
+    const testimonyPage = new TestimonyPage(page)
+    testimonyPage.removePresetCourtfilter()
+
+    const endorseCheckbox = page.getByRole("checkbox", { name: /endorse/i })
+    await endorseCheckbox.check({ timeout: 30000 })
+
+    await expect(testimonyPage.positionFilterItem).toContainText("endorse")
+    await expect(page).toHaveURL(/.*position%5D%5B0%5D=endorse/)
   })
 
   test("should filter by position: neutral", async ({ page }) => {
-    const testimonyPage = new TestimonyPage(page);
-    testimonyPage.removePresetCourtfilter();
+    const testimonyPage = new TestimonyPage(page)
+    testimonyPage.removePresetCourtfilter()
 
-    const checkNeutral = page.getByRole("checkbox", { name: "neutral" });
-    await checkNeutral.check({timeout:30000});
-    await page.getByRole("checkbox", { name: "neutral" }).check();
-    
-    await expect(testimonyPage.positionFilterItem).toContainText("neutral");
-    await expect(page).toHaveURL(/.*position%5D%5B0%5D=neutral/);
+    const checkNeutral = page.getByRole("checkbox", { name: "neutral" })
+    await checkNeutral.check({ timeout: 30000 })
+    await page.getByRole("checkbox", { name: "neutral" }).check()
+
+    await expect(testimonyPage.positionFilterItem).toContainText("neutral")
+    await expect(page).toHaveURL(/.*position%5D%5B0%5D=neutral/)
   })
 
   test("should filter by bill", async ({ page }) => {
-    const testimonyPage = new TestimonyPage(page);
-    testimonyPage.removePresetCourtfilter();
-    
+    const testimonyPage = new TestimonyPage(page)
+    testimonyPage.removePresetCourtfilter()
+
     const billCheckbox = page.getByLabel(/^[S|H]\d{1,4}$/).first()
     const billId = await billCheckbox.inputValue()
     expect(billId).toBeTruthy()
@@ -141,9 +141,9 @@ test.describe("Testimony Filtering", () => {
   })
 
   test("should filter by author", async ({ page }) => {
-    const testimonyPage = new TestimonyPage(page);
-    testimonyPage.removePresetCourtfilter();
-    
+    const testimonyPage = new TestimonyPage(page)
+    testimonyPage.removePresetCourtfilter()
+
     const writtenByText = await page
       .getByText(/Written by/)
       .first()
@@ -165,16 +165,16 @@ test.describe("Testimony Filtering", () => {
 
 test.describe("Testimony Sorting", () => {
   test("should sort by new -> old", async ({ page }) => {
-    const testimonyPage = new TestimonyPage(page);
-    await testimonyPage.sort("Sort by New -> Old");
-    const sortValue = page.getByText("Sort by New -> Old", { exact: true });
-    await expect(sortValue).toBeVisible();
+    const testimonyPage = new TestimonyPage(page)
+    await testimonyPage.sort("Sort by New -> Old")
+    const sortValue = page.getByText("Sort by New -> Old", { exact: true })
+    await expect(sortValue).toBeVisible()
   })
 
   test("should sort by old -> new", async ({ page }) => {
-    const testimonyPage = new TestimonyPage(page);
-    await testimonyPage.sort("Sort by Old -> New");
-    const sortValue = page.getByText("Sort by Old -> New", { exact: true });
-    await expect(sortValue).toBeVisible();
+    const testimonyPage = new TestimonyPage(page)
+    await testimonyPage.sort("Sort by Old -> New")
+    const sortValue = page.getByText("Sort by Old -> New", { exact: true })
+    await expect(sortValue).toBeVisible()
   })
 })


### PR DESCRIPTION
# Summary

_Add a short summary of the changes, and a reference to the original issue using `#` and the issue number, like #1_

# Checklist

- [ ] I amended code to address bugs that lead to failed playwright tests for browse-bills, and testimony. 
- [ ] I made changes to both the spec and object files in the e2e folder.


# Known issues

These tests to complete successfully on chrom and firefox. Webkit was not addressed.

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. There are multiple ways to run the playwrite tests. I chose : 
`npx playwright test tests/e2e/testimony.spec.ts` 
`npx playwright test tests/e2e/browse-bills.spec.ts`

# Next Steps

- [ ] Write tests for the edit Profile page in accordance issue #1544 

