### PR TITLE
Added overflow-wrap: break-word to testimony description.

### DIFF
--- a/components/testimony/TestimonyContent/TestimonyContent.tsx
+++ b/components/testimony/TestimonyContent/TestimonyContent.tsx
@@ -26,6 +26,7 @@ export const TestimonyContent = styled<Props>(
 
   p {
     margin-top: 0rem;
+    overflow-wrap: break-word;
   }
 
   .added {


### PR DESCRIPTION
# Summary

Found testimony description pages did not wrap long words correctly, causing overflow text and breakage on mobile screens. Added overflow-wrap to prevent this.

# Checklist

- [x] Added overflow-wrap.
- [x] Tested result on mobile vertical, landscape, and desktop modes using yarn dev.

# Screenshots

Before:
<img width="1008" height="2244" alt="Screenshot_20251104-230817" src="https://github.com/user-attachments/assets/5d98e7f8-812d-465f-afdb-d9d878e98e53" />
After:
<img width="1008" height="2244" alt="Screenshot_20251104-230720" src="https://github.com/user-attachments/assets/a3524c86-7e20-4d7b-a9e3-364ee67b859d" />

# Known issues

N/A

# Steps to test/reproduce

1. Visit a testimony with a long string without word breaks (such as testimony/_L7nNJLP4PFDKX10hLUht/1 in the default testimony examples).
2. See if the string runs off the page and a scroll bar is added, or the page is otherwise obviously visually incorrect.