### PR TITLE
Update Firestore Indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -397,6 +397,20 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "startsAt",
           "order": "ASCENDING"
         }


### PR DESCRIPTION
This PR just updates the Firestore indexes json to reflect the new index for the query that fetches hearings to backfill into the new Typesense collection. We need this index for the backfill to run successfully (and missed the need for it in PR because of the layer of indirection the search indexer adds to the query usage).

I made this update by following the exception in the Firestore Function logs, creating the index in the console, and then running `firebase firestore:indexes > firestore.indexes.json` to copy that update into our `firestore.indexes.json`. 

@jicruz96 