### PR TITLE
Hearing Sidebar Tweaks

### DIFF
--- a/components/hearing/HearingDetails.tsx
+++ b/components/hearing/HearingDetails.tsx
@@ -109,8 +109,8 @@ export const HearingDetails = ({
         <></>
       )}
 
-      <div className={`row mt-4`}>
-        <Col className={`col-md-8`}>
+      <Row>
+        <Col className={`col-md-8 mt-4`}>
           <LegalContainer className={`pb-2 rounded`}>
             <Row
               className={`d-flex align-items-center justify-content-between`}
@@ -175,7 +175,7 @@ export const HearingDetails = ({
             hearingDate={hearingDate}
           />
         </div>
-      </div>
+      </Row>
     </Container>
   )
 }

--- a/components/hearing/HearingSidebar.tsx
+++ b/components/hearing/HearingSidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 import { useCallback, useEffect, useState } from "react"
 import type { ModalProps } from "react-bootstrap"
 import styled from "styled-components"
-import { Col, Image, Modal } from "../bootstrap"
+import { Col, Image, Modal, Row } from "../bootstrap"
 import { firestore } from "../firebase"
 import * as links from "../links"
 import { billSiteURL, Internal } from "../links"
@@ -64,6 +64,24 @@ function MemberItem({
     />
   )
 }
+
+const BillsBody = styled.div`
+  background-color: white;
+  max-height: 672px;
+  overflow-y: auto;
+
+  @media (max-width: 1400px) {
+    max-height: 605px;
+  }
+
+  @media (max-width: 1200px) {
+    max-height: 537px;
+  }
+
+  @media (max-width: 992px) {
+    max-height: 471px;
+  }
+`
 
 const ModalLine = styled.hr`
   border-color: #000000;
@@ -171,7 +189,7 @@ export const HearingSidebar = ({
 
   return (
     <>
-      <SidebarHeader className={`fs-6 fw-bold px-3 pb-2`}>
+      <SidebarHeader className={`fs-6 fw-bold mt-4 px-3 pb-2`}>
         {t("hearing_details", { ns: "hearing" })}
       </SidebarHeader>
 
@@ -270,7 +288,7 @@ export const HearingSidebar = ({
         </SidebarBody>
       )}
       {billsInAgenda && (
-        <SidebarBody className={`border-bottom border-top fs-6 px-3 py-3`}>
+        <BillsBody className={`border-bottom border-top fs-6 px-3 py-3`}>
           <div className={`fw-bold`}>
             {t("bills_consideration", { ns: "hearing" })} (
             {billsInAgenda.length})
@@ -283,7 +301,7 @@ export const HearingSidebar = ({
               generalCourtNumber={generalCourtNumber}
             />
           ))}
-        </SidebarBody>
+        </BillsBody>
       )}
       <SidebarBottom className={`border-top`} />
     </>
@@ -502,6 +520,7 @@ function Vote({
   const { t } = useTranslation(["common", "hearing"])
   const [branch, setBranch] = useState<string>("")
   const [memberName, setMemberName] = useState<string>("")
+  const [party, setParty] = useState<string>("")
 
   const memberData = useCallback(async () => {
     const memberList = await getDoc(
@@ -514,6 +533,7 @@ function Vote({
 
     setBranch(docData?.content.Branch)
     setMemberName(docData?.content.Name)
+    setParty(docData?.content.Party)
   }, [])
 
   useEffect(() => {
@@ -523,14 +543,17 @@ function Vote({
   return (
     <VoteRow className={`d-flex justify-content-between`}>
       <VoteValue className={`ms-4`}>{t(value, { ns: "hearing" })}</VoteValue>
-      <Col className={`d-flex justify-content-start `} xs={5}>
-        <div>
+      <Col className={`d-block justify-content-start `} xs={5}>
+        <Row>
           <links.External
             href={`https://malegislature.gov/Legislators/Profile/${element.MemberCode}`}
           >
             {memberName}
           </links.External>
-        </div>
+        </Row>
+        <Row className={`ps-4`}>
+          <em>{party}</em>
+        </Row>
       </Col>
       <div className={`me-4`}>{branch}</div>
     </VoteRow>

--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -54,7 +54,7 @@ const TranscriptBottom = styled(Container)`
 `
 
 const TranscriptContainer = styled(Container)`
-  max-height: 18rem;
+  max-height: 460px;
   overflow-y: auto;
   background-color: #ffffff;
 `


### PR DESCRIPTION
# Summary

* Adjust Translation container height
* Adjust Sidebar Bill section to conform to bottom of Translation container across view sizes
* add Party affiliation to Votes Modal

<img width="216" height="35" alt="image" src="https://github.com/user-attachments/assets/f7bfe843-6654-4781-b0b3-1336ad693118" />

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.
- [n/a] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

<img width="1213" height="629" alt="image" src="https://github.com/user-attachments/assets/9bcc0454-c5f1-435a-a883-82e6b44e21dc" />

<img width="904" height="485" alt="image" src="https://github.com/user-attachments/assets/783acb8f-6bc3-4767-b79e-ab719e2b3fab" />

<img width="488" height="762" alt="image" src="https://github.com/user-attachments/assets/d35590f8-1833-46aa-9ad0-3f2a0a28b189" />

# Known issues

none at this time

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the /hearing/5252
2. Enjoy 🍰 
