### PR TITLE
Removed internal flexbox for footer base; changed to div which occupi…

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -279,21 +279,17 @@ const PageFooter = (props: PageFooterProps) => {
         </Col>
       </div>
       <MapleContainer className={`col-auto order-md-2 justify-self-end `} />
-      <div
-        className={`d-flex flex-column gap-2 flex-md-row flex-wrap col-12 flex-shrink-0 order-md-3 text-center text-md-start`}
-      >
-        <Col className="text-white col-md-auto">
-          {t("legal.disclaimer")}
-          {" - "}
-          <a
-            href={NEWSLETTER_SIGNUP_URL}
-            style={{ color: "white" }}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t("newsletter")}
-          </a>
-        </Col>
+      <div className={`col-12 order-md-3 text-center text-md-start text-white`}>
+        {t("legal.disclaimer")}
+        {" - "}
+        <a
+          href={NEWSLETTER_SIGNUP_URL}
+          style={{ color: "white" }}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t("newsletter")}
+        </a>
       </div>
     </FooterContainer>
   )


### PR DESCRIPTION
# Summary
Changed the footer disclaimer so that the text would wrap rather than expanding website window on medium screens.

## Explanation
The internal \<Col\> element with the className of col-md-auto forced the text to be full content width on medium screens, disabling text wrapping.

## Resolution
Given the legal disclaimer was a flexbox \<div\> with a single \<Col\> element, I combined the two to a full width (so it falls below the rest of the flex items) div, and removed the flex so that the text wrapped inline. It may have alternatively been the intention to have the newsletter link below the disclaimer, in which case the flexbox would be kept.

# Checklist

- [x] I've made pages responsive and look good on mobile.
Tested vertical/horizontal view on mobile.

# Screenshots
Original:
<img width="817" height="898" alt="Captura de pantalla_20251111_221059" src="https://github.com/user-attachments/assets/3fce8079-08f2-4fd1-9953-f518100b308d" />
Altered:
<img width="817" height="898" alt="Captura de pantalla_20251111_221143" src="https://github.com/user-attachments/assets/0d19b940-0961-47be-babb-997ee2c62f2d" />

# Known issues
N/A

# Steps to test/reproduce
The / page should have the footer displayed in the following ways:
Mobile (vertical) behavior: Disclaimer should be between the Navbar and 'Follow MAPLE', wrapping. 
Mobile (horizontal) & medium browser behavior: Disclaimer text should be on the bottom of the footer and wrap, not expanding past the edge of the page.
Large browser behavior: Disclaimer text should be on the bottom of the footer.