### PR TITLE
Navbar browse overlap fix

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -185,7 +185,10 @@ const DesktopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation(["common", "auth"])
 
   return (
-    <Container fluid className={`bg-secondary d-flex py-2 sticky-top justify-content-end`}>
+    <Container
+      fluid
+      className={`bg-secondary d-flex py-2 sticky-top justify-content-end`}
+    >
       <div className={`me-auto`}>
         <NavbarLinkLogo />
       </div>


### PR DESCRIPTION
# Summary

Fixed the overlap of 'Browse Bills' and 'Browse Hearings' on the navbar.  
Removed 'Placeholder search widget' (this implicitly makes navbar elements fall to the left rather than right).
Log in / Sign up sticks to the right side of the navbar in desktop.
Switched \<Nav\> elements for div padding.

# Checklist

- [X] I've made pages responsive and look good on mobile.
Checked on mobile while NOT LOGGED IN. Logging in with Google does not appear to work on localhost? Is there a guest account in dev mode? Nevertheless, there should not be problems here.

# Screenshots

Before:  
<img width="765" height="701" alt="Captura de pantalla_20251118_014542" src="https://github.com/user-attachments/assets/6d515db2-e31d-4551-9f61-f9f3c37e1a59" />
After:  
<img width="764" height="697" alt="Captura de pantalla_20251118_014416" src="https://github.com/user-attachments/assets/64a2d77a-52de-4c55-869d-85b1a6b34f61" />

# Known issues

None.

# Steps to test/reproduce

1. Go to the home page
2. Check how the navbar handles page shrinking until mobile mode
3. Log in
4. Check how the navbar handles page shrinking until mobile mode
5. Click each navbar element. Ensure functionality still works
6. Make sure navbar looks proper on mobile vertical/horizontal, especially when logged in