### PR TITLE
Moved committee filter higher in hearings search

### DIFF
--- a/components/search/hearings/HearingSearch.tsx
+++ b/components/search/hearings/HearingSearch.tsx
@@ -90,9 +90,9 @@ export const HearingSearch = () => {
                 }))
                 .sort((a, b) => Number(b.value) - Number(a.value))
           },
+          { attribute: "committeeName" },
           { attribute: "month" },
           { attribute: "year" },
-          { attribute: "committeeName" },
           {
             attribute: "chairNames",
             transformItems: items =>


### PR DESCRIPTION
# Summary

Closes #1990.  
Changed committee to second hearing search parameter.

# Checklist

N/A

# Screenshots

<img width="2228" height="1401" alt="Captura de pantalla_20251125_220148" src="https://github.com/user-attachments/assets/c263a3bd-fffa-4e39-ae6d-0f79d351f9ba" />

# Known issues

N/A

# Steps to test/reproduce

1. Go to /hearings.
2. Check that the committee search filter is second in the list.
