### PR TITLE
Enable Transcriptions on Prod

### DIFF
--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -44,7 +44,7 @@ const defaults: Record<Env, FeatureFlags> = {
     followOrg: true,
     lobbyingTable: false,
     showLLMFeatures: true,
-    hearingsAndTranscriptions: false
+    hearingsAndTranscriptions: true
   },
   test: {
     testimonyDiffing: false,


### PR DESCRIPTION
# Summary

This PR flips the flag for hearings and transcriptions from disabled to enabled for production - this will make the Browse Hearings, Hearing Detail, and Bill links page visible on the production site.
