### PR TITLE
Transcript auto-scrolls to match video playback

### DIFF
--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -147,9 +147,9 @@ export const Transcriptions = ({
       const currentIndex = transcriptData.findIndex(
         element => videoRef.current.currentTime <= element.end / 1000
       )
-      if (currentIndex !== -1 && containerRef.current && currentIndex !== highlightedId) {
+      if (containerRef.current && currentIndex !== highlightedId) {
         setHighlightedId(currentIndex)
-        if (!searchTerm) {
+        if (currentIndex !== -1 && !searchTerm) {
           const container = containerRef.current
           const elem = transcriptRefs.current.get(currentIndex)
           const elemTop = elem.offsetTop - container.offsetTop


### PR DESCRIPTION
# Summary

Closes #1992.  
Added transcript auto-scroll to hearing playback. If the video is playing or seeked (as per the timeupdate event listener), the transcript will scroll to the location of video playback.  

# Checklist

- [x] I've made pages responsive and look good on mobile.
Checked on mobile.

# Screenshots

<img width="1267" height="897" alt="Captura de pantalla_20251209_120428" src="https://github.com/user-attachments/assets/cdd373d4-0f40-45ad-86dc-c1018812525f" />

# Known issues

- According to https://react.dev/reference/react/forwardRef, forwardRef seems like it will be deprecated after moving to React 19.

# Steps to test/reproduce

1. Go to a /hearing/#### page
2. Play video; as video playback advances, the transcript should move to that location.
3. If the video is seeked to a new position (check both forward and backward seek), the transcript scroll should shift so that it is aligned with the video seek.
4. Verify that when there is an active search term, the active transcript element is highlighted but not scrolled to.
