### PR TITLE
Added badge to unavailable videos

### DIFF
--- a/components/search/hearings/HearingHit.tsx
+++ b/components/search/hearings/HearingHit.tsx
@@ -100,7 +100,11 @@ export const HearingHit = ({ hit }: { hit: HearingHitData }) => {
               <Badge bg="success" pill>
                 {t("video_available", { ns: "search" })}
               </Badge>
-            ) : null}
+            ) : (
+              <Badge bg="info" text="dark" pill>
+                {t("video_unavailable", { ns: "search" })}
+              </Badge>
+            )}
           </div>
 
           <div>

--- a/public/locales/en/search.json
+++ b/public/locales/en/search.json
@@ -46,6 +46,7 @@
   },
   "search_error": "Something went wrong. Please try again. Original message: {{error}}",
   "video_available": "Video available",
+  "video_unavailable": "Video and transcript not yet available",
   "location_label": "Location",
   "agenda_label": "Agenda Topics",
   "bills_label": "Bills",


### PR DESCRIPTION
# Summary

Videos that are unavailable now have a badge that states 'Video and transcript not available'.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

<img width="1049" height="901" alt="Captura de pantalla_20251209_204952" src="https://github.com/user-attachments/assets/ba67c6aa-3b06-437d-a3be-21e96638d918" />

# Known issues

Badge color/text may still be debated.

# Steps to test/reproduce

1. Check items in /hearings that do not have a video available badge have a video not available badge.
