### PR TITLE
add hover behavior to transcription timestamps

### DIFF
--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -1,13 +1,7 @@
 import { faMagnifyingGlass, faTimes } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { useTranslation } from "next-i18next"
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from "react"
+import React, { forwardRef, useEffect, useRef, useState } from "react"
 import styled from "styled-components"
 import { Col, Container, Row } from "../bootstrap"
 import { Paragraph, formatMilliseconds } from "./transcription"


### PR DESCRIPTION
# Summary

<img width="812" height="603" alt="image" src="https://github.com/user-attachments/assets/22e2df17-c008-44cc-91ab-9a9582b70e22" />

# Checklist

- [n/a] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [n/a] I've made pages responsive and look good on mobile.
- [n/a] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

<img width="887" height="293" alt="image" src="https://github.com/user-attachments/assets/9dca8d3f-67d5-4f24-baa9-59ae1fe5ed40" />

<img width="914" height="290" alt="image" src="https://github.com/user-attachments/assets/2fc25a86-2acb-4252-898f-cb3c407b50d8" />

# Known issues

none at present

# Steps to test/reproduce

1. go to a hearing with a transcription
2. hover over a timestamp
3. check that timestamp bolds and underlines when you hover over it and doesn't bold and underline when you cease to hover over it
