### PR TITLE
Transcript search fix

### DIFF
--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -289,11 +289,17 @@ const TranscriptItem = forwardRef(function TranscriptItem(
   }
   const highlightText = (text: string, term: string) => {
     if (!term) return text
-    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
     const regex = new RegExp(`(${escaped})`, "gi")
-    return text
-      .split(regex)
-      .map((part, i) => (regex.test(part) ? <mark key={i} className={`p-0`}>{part}</mark> : part))
+    return text.split(regex).map((part, i) =>
+      regex.test(part) ? (
+        <mark key={i} className={`p-0`}>
+          {part}
+        </mark>
+      ) : (
+        part
+      )
+    )
   }
 
   return (


### PR DESCRIPTION
# Summary

- Escaped search string regex (now searches exact string match)
- Removed padding on \<mark\> elements

# Screenshots

<img width="2881" height="1468" alt="Captura de pantalla_20251216_184145" src="https://github.com/user-attachments/assets/ed4238df-1fed-44fa-8a72-54ebc205750f" />

# Known issues

None

# Steps to test/reproduce

1. Navigate to hearing transcript page
1. Check that search functionality is functional
1. Ensure that search highlighting does not space out text
1. Ensure regex special characters ('.', '(', etc) search normally