### PR TITLE
fix(types): Updating HearingContent's PrimarySponsor type 

### DIFF
--- a/functions/src/events/types.ts
+++ b/functions/src/events/types.ts
@@ -77,7 +77,7 @@ export const HearingContent = BaseEventContent.extend({
         Record({
           BillNumber: String,
           GeneralCourtNumber: Number,
-          PrimarySponsor: Nullable(Record({ Id: String })),
+          PrimarySponsor: Nullable(Record({ Id: Nullable(String) })),
           Title: String
         })
       ),


### PR DESCRIPTION
This accounts for the fact that the Id can be null (if the primary sponsor is not a member of the legislature). This happens infrequently... but it can happen, so we should be prepared