### PR TITLE
removing agenda topics from hearing hits search results

### DIFF
--- a/components/search/hearings/HearingHit.tsx
+++ b/components/search/hearings/HearingHit.tsx
@@ -139,13 +139,6 @@ export const HearingHit = ({ hit }: { hit: HearingHitData }) => {
             </div>
           ) : null}
 
-          {topics.length ? (
-            <div>
-              <SectionLabel>{t("agenda_label", { ns: "search" })}</SectionLabel>
-              <span>{topics.join(", ")}</span>
-            </div>
-          ) : null}
-
           <BillsSection bills={bills} />
         </div>
       </Card.Body>


### PR DESCRIPTION
# Summary

#1989 , removed Agenda Topics from appearing in hearing search results.  Used to be listed below "location" and above "Bills".

# Checklist

- [X ] On the frontend, I've made my strings translate-able.

- [ X] I've made pages responsive and look good on mobile.


# Screenshots
<img width="1710" height="826" alt="image" src="https://github.com/user-attachments/assets/b221f65d-2359-4522-bc21-f164cba3fc02" />




# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
2. Browse Hearings
3. You should no longer see 'Agenda Topics' listing in hearing results - used to be listed below "location" and above "Bills".