### PR TITLE
Fix spelling error on advisory page

### DIFF
--- a/components/OurTeam/AdvisoryBoard.tsx
+++ b/components/OurTeam/AdvisoryBoard.tsx
@@ -33,7 +33,7 @@ export const AdvisoryBoard = () => {
             <MemberItem name="Marci Harris" descr={t("advisory.MHarris")} />
             <Divider />
             <MemberItem
-              name="Jake Hirsh-Allen"
+              name="Jake Hirsch-Allen"
               descr={t("advisory.JakeHirshAllen")}
             />
             <Divider />


### PR DESCRIPTION
# Summary

Fixed the spelling of Jake Hirsch-Allen on advisory page.

# Checklist

N/A

# Screenshots
![JakeHirschAllenn-SpellingChange](https://github.com/user-attachments/assets/e4632c74-ef98-4720-b99a-459f1794928c)


# Known issues
N/A

# Steps to test/reproduce

1. Go to  advisory page
2. Confirm correct spelling of Jake Hirsch-Allen. Was previously Jake Hirsh-Allen, without a "c"
