### PR TITLE
Added hasVideo filter

### DIFF
--- a/components/search/hearings/HearingSearch.tsx
+++ b/components/search/hearings/HearingSearch.tsx
@@ -83,7 +83,10 @@ export const HearingSearch = () => {
       currentRefinementsProps={{ excludedAttributes: ["startsAt"] }}
       initialUiState={{
         [sortOptions[0].value]: {
-          refinementList: { court: [String(CURRENT_COURT_NUMBER)] }
+          refinementList: {
+            court: [String(CURRENT_COURT_NUMBER)],
+            hasVideo: ["true"]
+          }
         }
       }}
       searchParameters={{
@@ -103,6 +106,14 @@ export const HearingSearch = () => {
                   label: formatCourtFilterLabel(parseInt(item.value, 10))
                 }))
                 .sort((a, b) => Number(b.value) - Number(a.value))
+          },
+          {
+            attribute: "hasVideo",
+            transformItems: items =>
+              items.map(item => ({
+                ...item,
+                label: item.value === "true" ? "Yes" : "No"
+              }))
           },
           { attribute: "committeeName" },
           { attribute: "month" },

--- a/public/locales/en/search.json
+++ b/public/locales/en/search.json
@@ -21,6 +21,7 @@
     },
     "hearing": {
       "court": "Legislative Session",
+      "hasVideo": "Video Available",
       "month": "Month",
       "year": "Year",
       "chairNames": "Chair",


### PR DESCRIPTION
# Summary

Added a hearing filter for the 'hasVideo' attribute.

# Checklist

- [x] On the frontend, I've made my strings translate-able.

# Screenshots

<img width="2559" height="1581" alt="Captura de pantalla_20260127_184643" src="https://github.com/user-attachments/assets/3abc89fa-0f4e-457b-8345-6a597e94bd83" />

# Steps to test/reproduce

1. Check hearings search has a 'Video Available' filter
2. Verify it functions correctly
