### PR TITLE
Scrape Single function to firebase v2

### DIFF
--- a/components/moderation/ScrapeHearing.tsx
+++ b/components/moderation/ScrapeHearing.tsx
@@ -16,6 +16,11 @@ const scrapeSingleHearing = httpsCallable<
   ScrapeHearingResponse
 >(functions, "scrapeSingleHearing")
 
+const scrapeSingleHearingv2 = httpsCallable<
+  ScrapeHearingRequest,
+  ScrapeHearingResponse
+>(functions, "scrapeSingleHearingv2")
+
 export const ScrapeHearingForm = () => {
   const [eventId, setEventId] = useState("")
   const [loading, setLoading] = useState(false)
@@ -39,7 +44,7 @@ export const ScrapeHearingForm = () => {
 
     setLoading(true)
     try {
-      const response = await scrapeSingleHearing({ eventId: parsedEventId })
+      const response = await scrapeSingleHearingv2({ eventId: parsedEventId })
       setResult({
         type: "success",
         message: `${response.data.message} (ID: ${response.data.hearingId})`

--- a/functions/src/common.ts
+++ b/functions/src/common.ts
@@ -1,6 +1,7 @@
 import { FieldValue } from "@google-cloud/firestore"
 import axios from "axios"
 import { https, logger } from "firebase-functions"
+import { CallableRequest } from "firebase-functions/v2/https"
 import {
   Null,
   Nullish,
@@ -38,7 +39,7 @@ export function checkRequestZod<T extends ZodTypeAny>(
 
 /** Return the authenticated user's id or fail if they are not authenticated. */
 export function checkAuth(
-  context: https.CallableContext,
+  context: https.CallableContext | CallableRequest,
   checkEmailVerification = false
 ) {
   const uid = context.auth?.uid
@@ -61,7 +62,7 @@ export function checkAuth(
 /**
  * Checks that the caller is an admin.
  */
-export function checkAdmin(context: https.CallableContext) {
+export function checkAdmin(context: https.CallableContext | CallableRequest) {
   const callerRole = context.auth?.token.role
   if (callerRole !== "admin") {
     throw fail("permission-denied", "You must be an admin")

--- a/functions/src/events/index.ts
+++ b/functions/src/events/index.ts
@@ -1,2 +1,3 @@
 export * from "./scrapeEvents"
 export { scrapeSingleHearing } from "./scrapeEvents"
+export { scrapeSingleHearingv2 } from "./scrapeEvents"

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -19,7 +19,8 @@ export {
   scrapeHearings,
   scrapeSessions,
   scrapeSpecialEvents,
-  scrapeSingleHearing
+  scrapeSingleHearing,
+  scrapeSingleHearingv2
 } from "./events"
 export {
   syncHearingToSearchIndex,


### PR DESCRIPTION
# Summary
1. Added a v2 version of the scrape single hearing function that uses a firebase v2 function. The function signature is a bit different. OnCall is imported directly instead of from the https module and there is only one argument
2. I changed the import names to mark the v1 firebase modules more clearly by adding /v1 to the end. 
3. Refactored the checkAuth and checkAdmin functions to take an argument of type CallableRequest or the old type: https.CallableContext.
4. The front end now calls the v2 function in the Scrape Hearing Form Function.  

Closes #2041 

# Known issues
I did also keep in the old scrape single hearing function but if this works as expected this is unnecessary and can be deleted.

# Steps to test/reproduce
1. I'm not actually sure how to invoke this function but it should be somewhere under the admin page of the hearings tab.