### PR TITLE
Remove mentions of ZenHub from project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,4 +253,4 @@ Thanks to all our contributors!
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This table follows the [All Contributors](https://allcontributors.org/) specification and is managed by the @all-contributors bot. You can add yourself or another contributor by [commenting on an issue or a pull request](https://allcontributors.org/docs/en/bot/usage).
+This table follows the [All Contributors](https://allcontributors.org/) specification and is managed by the @all-contributors bot. You can add yourself or another contributor by [commenting on an issue or a pull request](https://allcontributors.org/bot/usage/).


### PR DESCRIPTION
# Summary
Removes mentions of ZenHub from README since it's no longer used.
Also fixes broken link to all contributors bot.

Closes #2049 


# Checklist
(all n/a - just a quick doc update)

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.
- [x] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots
_Add some screenshots highlighting your changes._
n/a

# Known issues
_If you've run against limitations or caveats, include them here. Include follow-up issues as well._
n/a

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Load README file
1. CTRL+F 'ZenHub'
2. Verify no mentions of ZenHub
3. Click final link in README
4. Verify that link takes you to https://allcontributors.org/bot/usage/
