### PR TITLE
Transcription hover element

### DIFF
--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -370,7 +370,7 @@ const TranscriptItem = forwardRef(function TranscriptItem(
     <>
       {isHighlighted(index) ? (
         <TranscriptRowActive
-          className={`bg-info border-5 border-start`}
+          className={`bg-info border-5 border-secondary border-start`}
           ref={ref}
         >
           <TimestampCol>


### PR DESCRIPTION
# Summary

refactor whenHovered state for Transcription elements

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.
- [n/a] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

<img width="787" height="561" alt="image" src="https://github.com/user-attachments/assets/3ab9d983-5209-40e6-adc8-98ab01469cfa" />

# Known issues

none at present

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go a page with a hearing video
2. hover over various transcription rows
3. see that when a row,  other than the active row relative to the video time, changes color and displays the update arrow
4. click the update arrow and see that the video and transcription move to the corresponding timestamp
