### PR TITLE
Add Script to Migrate Emails from profiles to users collection

### DIFF
--- a/scripts/firebase-admin/migrateProfileEmails.ts
+++ b/scripts/firebase-admin/migrateProfileEmails.ts
@@ -1,0 +1,47 @@
+import { FieldValue } from "functions/src/firebase"
+import { Script } from "./types"
+
+// Migrate emails from profiles to users collection and delete from profiles
+export const script: Script = async ({ db, auth }) => {
+  const profilesSnapshot = await db
+    .collection("profiles")
+    .where("email", ">", "")
+    .get()
+  let emailUpdateCount = 0
+
+  console.log(`Migrating emails for ${profilesSnapshot.size} profiles`)
+
+  const bulkWriter = db.bulkWriter()
+
+  for (const profileDoc of profilesSnapshot.docs) {
+    const profileData = profileDoc.data()
+    const userId = profileDoc.id
+    const email = profileData.email
+
+    if (email) {
+      const userRef = db.collection("users").doc(userId)
+      const userDoc = await userRef.get()
+      const userEmail = userDoc.exists ? userDoc.data()?.email : undefined
+
+      if (userEmail) {
+        if (userEmail !== email) {
+          console.error(
+            `Email mismatch for userId ${userId}: profile email "${email}", user email "${userEmail}"`
+          )
+        } else {
+          // Email is the same, just delete from profile collection
+          bulkWriter.update(profileDoc.ref, { email: FieldValue.delete() })
+        }
+      } else {
+        // No email in user collection, set it
+        bulkWriter.set(userRef, { email }, { merge: true })
+        bulkWriter.update(profileDoc.ref, { email: FieldValue.delete() })
+        emailUpdateCount++
+      }
+    }
+  }
+
+  await bulkWriter.close()
+
+  console.log(`Updated emails for ${emailUpdateCount} users`)
+}


### PR DESCRIPTION
# Summary

This script migrates email addresses from the `profiles` collection to the `users` collection in Firestore.

- For each profile document with an email:
  - Checks if the corresponding user document already has an email.
    - **If the user document does not have an email:**  
      - Copies the email from `profiles` to `users`.
      - Deletes the email field from the profile document.
    - **If the emails are the same:**  
      - Deletes the email field from the profile document.
    - **If the emails are different:**  
      - Logs an error with the user ID and both email values, then skips updating.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. yarn firebase-admin -e local run-script migrateProfileEmails
2. Check if emails are migrated over properly
