### PR TITLE
fix: add a missing await in tests/integration/common

### DIFF
--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -57,7 +57,7 @@ export async function createNewBill(props?: Partial<Bill>) {
 
   expect(Bill.validate(bill).success).toBeTruthy()
 
-  testDb
+  await testDb
     .doc(`/generalCourts/${currentGeneralCourt}/bills/${billId}`)
     .create({
       ...bill,


### PR DESCRIPTION
# Summary

Calls to testDb.create have to be awaited even if they go through a catch. This was a race condition that could be triggered on slower machines, etc.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
