### PR TITLE
Truncate bill summary to 1000 chars and add modal for longer summaries

### DIFF
--- a/components/bill/Summary.tsx
+++ b/components/bill/Summary.tsx
@@ -104,11 +104,14 @@ export const ViewMessage = styled.div`
   }
 `
 
+const BALLOT_SUMMARY_CHAR_LIMIT = 1000
+
 export const Summary = ({
   bill,
   className
 }: BillProps & { className?: string }) => {
   const [showBillDetails, setShowBillDetails] = useState(false)
+  const [showFullSummary, setShowFullSummary] = useState(false)
   const handleShowBillDetails = () => setShowBillDetails(true)
   const handleHideBillDetails = () => setShowBillDetails(false)
   const billText = bill?.content?.DocumentText
@@ -221,7 +224,36 @@ export const Summary = ({
           )}
           {bill.summary !== undefined && isBallotMeasure ? (
             <BallotSummaryRow className={`mx-1 mb-3`}>
-              {bill.summary}
+              {bill.summary.length > BALLOT_SUMMARY_CHAR_LIMIT ? (
+                <>
+                  {bill.summary.slice(0, BALLOT_SUMMARY_CHAR_LIMIT)}…{" "}
+                  <StyledButton
+                    variant="link"
+                    onClick={() => setShowFullSummary(true)}
+                  >
+                    {t("bill.view_full_summary")}
+                  </StyledButton>
+                  <Modal
+                    show={showFullSummary}
+                    onHide={() => setShowFullSummary(false)}
+                    size="lg"
+                  >
+                    <Modal.Header
+                      closeButton
+                      onClick={() => setShowFullSummary(false)}
+                    >
+                      <Modal.Title>{bill?.id}</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body className="bg-white">
+                      <FormattedBillDetails>
+                        {bill.summary}
+                      </FormattedBillDetails>
+                    </Modal.Body>
+                  </Modal>
+                </>
+              ) : (
+                bill.summary
+              )}
             </BallotSummaryRow>
           ) : (
             <Row className="mx-1 mb-3">{bill.summary}</Row>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -65,7 +65,8 @@
     "smart_tag": "AI Smart Tag",
     "status_and_history": "Status & History",
     "status_history": "Status History",
-    "view_bill": "View Bill Text" 
+    "view_bill": "View Bill Text",
+    "view_full_summary": "View Full Summary"
   },
   "bill_updates": "Bill Updates",
   "browse_bills": "browse bills",


### PR DESCRIPTION
# Summary

This PR just provides a slightly better experience for ballot initiative bills with longer summaries - we now truncate the summary to 1000 chars and add a modal for longer summaries (similar to the bill text modal).

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [N/A] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.
- [N/A] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

TBD

# Known issues

N/A

# Steps to test/reproduce

1. Go to a ballot initiative bill page with a short summary (like `/bills/194/H5001`) and confirm that there is no modal trigger
2. Go to a ballot initiative bill page with a long summary (like `/bills/194/H5010`) and confirm that the modal triggers as expected.
