### PR TITLE
timestamp conflict resolution

### DIFF
--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -200,7 +200,7 @@ export const Transcriptions = ({
   const resultString: string = convertToString(startTime)
 
   let currentIndex = transcriptData.findIndex(
-    element => parseInt(resultString, 10) <= element.end / 1000
+    element => parseInt(resultString, 10) < element.end / 1000
   )
 
   // Set the initial scroll target when we have a startTime and transcripts
@@ -233,7 +233,7 @@ export const Transcriptions = ({
     const handleTimeUpdate = () => {
       videoLoaded
         ? (currentIndex = transcriptData.findIndex(
-            element => videoRef.current.currentTime <= element.end / 1000
+            element => videoRef.current.currentTime < element.end / 1000
           ))
         : null
       if (containerRef.current && currentIndex !== highlightedId) {


### PR DESCRIPTION
# Summary

Issue #2064 

# Checklist

N/A

# Screenshots

![champagne-barbie-cookie-monster](https://github.com/user-attachments/assets/d52d3778-6d04-4a35-87a1-f5059229a2da)

# Known issues

none

# Steps to test/reproduce

1. Go to ../hearing/5627
2. Go to the translation element with timestamp 00:41 - 01:08
3. Make sure some other element is highlighted first
4. Click on either the timestamp or the arrow that appears on the right side of the element when it is hovered upon
5. Check that the correct element highlights and NOT the element with timestamp 00:02 - 00:41
