### PR TITLE
fixing race condition on phone number authentication

### DIFF
--- a/components/EditProfilePage/PhoneVerificationModal.tsx
+++ b/components/EditProfilePage/PhoneVerificationModal.tsx
@@ -130,6 +130,10 @@ export default function PhoneVerificationModal({
     setVerifying(true)
     try {
       await confirmationResult.confirm(code.trim())
+
+      // Force fresh token to ensure context.auth is populated
+      await auth.currentUser?.getIdToken(true)
+
       if (completePhoneVerification.execute) {
         await completePhoneVerification.execute()
       }


### PR DESCRIPTION
# Summary

When testing change, from issue #2013, made in commit 6278b4c, found an issue where the phone number get associated with the account, but we get an error when calling completePhoneVerification, because the context.auth token hasn't been refreshed.by the time the completePhoneVerification call is made. This change fixes that issue. 


# Checklist

- [n/a] On the frontend, I've made my strings translate-able.
- [n/a ] If I've added shared components, I've added a storybook story.
- [n/a] I've made pages responsive and look good on mobile.
- [n/a ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may recommend it - indexes created this way may be obliterated by subsequent deploys)

# Steps to test/reproduce

Step 1:
In MAPLE, Create a new user by going through the sign up process.

Step 2:
Open the firebase console > firestore
Find the profile of the user you added.
[Can do this by going to profiles collection. Filter for field: fullName.  Scroll down to find the name of the user you created.]
Notice there is no “phoneVerified” field. Leave this tab open in your browser. After we do the verification, we’ll confirm here that there is now “phoneVerified” field set to true.

Step 3:
Back in MAPLE, navigate to the edit profile page.
Click the “Get Verified” button on the right

When  “Verify your phone number” modal pops up,
Enter 650-777-7777. 
When pop-up changes to expect a verification code, enter 123456

NOTE: For additional tests, will have to create new known testing phone numbers in the Firebase console > Authentication > Phone > "Phone numbers for testing"


Step 4:
The popup should have disappeared.
Confirm that the button on the right in the Edit profile page has been removed and now there is static text that says “Verified User”

Step 5:
Back in the firebase console, firestore page, confirm that the profile document for your user now has ““phoneVerified: true”
Can also look at thw users column in Firebase console > Authentication, and see that “provider” column for the expected user now shows both email and phone

Step 6:
TESTING invalid number:

Log out and create a new user.
Go to Edit Profile and click Get Verified
Try entering a phone number that is too short.
Confirm that you see the error message "Please enter a valid phone number”

Repeat with a phone number that is
-too long
-starts with a 1

Step 7:
TESTING phone number already in use.
Log out and create a new user.
Go to Edit Profile and click Get Verified
Enter the same phone number you used for the already verified account and enter the expected code 
Confirm that you see the error message "This phone number is already linked to another account."

Step 8:
Testing operation-not-allowed:
To test that this error will show as expected, temporarily disable Phone sign-in in Firebase Console → Authentication → Sign-in method. Go through the phone verification process. Confirm that the error
shown is "Phone verification is not enabled. Please try again later or contact us at [info@mapletestimony.org](mailto:info@mapletestimony.org)".