### PR TITLE
Fix the Admin Resolve Report function 

### DIFF
--- a/functions/src/testimony/resolveReport.ts
+++ b/functions/src/testimony/resolveReport.ts
@@ -5,7 +5,6 @@ import { fail, checkRequestZod, checkAuth, checkAdmin } from "../common"
 // import { performDeleteTestimony } from "./deleteTestimony"
 import { first } from "lodash"
 import { Testimony } from "./types"
-import { Profile } from "../profile/types"
 
 export type Request = z.infer<typeof Request>
 const Request = z.object({
@@ -45,12 +44,10 @@ export const resolveReport = functions.https.onCall(
 
     // 3. Get the moderator's profile document
     const moderatorUid = context.auth!.uid
-    const moderator = Profile.check(
-      await db
-        .doc(`profiles/${moderatorUid}`)
-        .get()
-        .then(d => d.data())
-    )
+    const moderatorName = await db
+      .doc(`profiles/${moderatorUid}`)
+      .get()
+      .then(d => d.data()?.fullName)
 
     // ***archived testiomny Id === published testimony Id***
 
@@ -76,7 +73,7 @@ export const resolveReport = functions.https.onCall(
       archivedTestimonyId: testimonyId
     }
     if (reason) resolutionObj.reason = reason
-    if (moderator.fullName) resolutionObj.moderatorName = moderator.fullName
+    if (moderatorName) resolutionObj.moderatorName = moderatorName
 
     await reportRef.update({
       resolution: resolutionObj


### PR DESCRIPTION
# Summary

This PR addresses the bug in the existing Admin Resolve Report firebase function - there is a validation error in `Profile.check` when we try to fetch and validate the moderator's profile (related to a Timestamp field), which currently prevents us from resolving testimony reports.

`fullName` is an optional field on both documents, and the ValidationError is unrelated to that field, so I've just removed the superfluous type check here. There is a broader concern about translating Firestore timestamps into/out of the provided types (especially given the mismatch between the front-end and back-end Firestore Timestamp types), but we can address that in a follow-up PR. 

# Checklist

- [N/A] On the frontend, I've made my strings translate-able.
- [N/A] If I've added shared components, I've added a storybook story.
- [N/A] I've made pages responsive and look good on mobile.
- [N/A] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce
1. Report a pre-existing testimony (or submit a testimony, then report it)
2. Go to the Resolve Reports admin page and try to resolve that report
3. Verify that it resolves successfully