### PR TITLE
MAPLE In The News Page

### DIFF
--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Col, Row, Container, Badge } from "../bootstrap"
+import { Col, Row, Container, Badge, Spinner } from "../bootstrap"
 import Tab from "react-bootstrap/Tab"
 import Nav from "react-bootstrap/Nav"
 import Dropdown from "react-bootstrap/Dropdown"
@@ -37,14 +37,15 @@ const NewsFeed = ({
 export const InTheNews = () => {
   const { t } = useTranslation("inTheNews")
   const isMobile = useMediaQuery("(max-width: 768px)")
-  const { result: newsItems = [] as NewsItem[] } = useNews()
+  const { result: newsItems, loading } = useNews()
 
-
-  const counts: TabCounts = {
-    media: newsItems.filter(item => item.type === "article").length,
-    awards: newsItems.filter(item => item.type === "award").length,
-    books: newsItems.filter(item => item.type === "book").length
-  }
+  const counts: TabCounts | null = newsItems
+    ? {
+        media: newsItems.filter(item => item.type === "article").length,
+        awards: newsItems.filter(item => item.type === "award").length,
+        books: newsItems.filter(item => item.type === "book").length
+      }
+    : null
 
   return (
     <Container className="ptx-4 pt-5 gap-4 min-vh-100">
@@ -54,23 +55,31 @@ export const InTheNews = () => {
           {isMobile ? <TabDropdown counts={counts} /> : <TabGroup counts={counts} />}
           <Row className="g-0">
             <Col>
-              <Tab.Content>
-                <Tab.Pane eventKey="media">
-                  <div className="d-flex flex-column align-items-center">
-                    <NewsFeed type="article" newsItems={newsItems} />
-                  </div>
-                </Tab.Pane>
-                <Tab.Pane eventKey="awards">
-                  <div className="d-flex flex-column align-items-center">
-                    <NewsFeed type="award" newsItems={newsItems} />
-                  </div>
-                </Tab.Pane>
-                <Tab.Pane eventKey="books">
-                  <div className="d-flex flex-column align-items-center">
-                    <NewsFeed type="book" newsItems={newsItems} />
-                  </div>
-                </Tab.Pane>
-              </Tab.Content>
+              {loading ? (
+                <div className="d-flex justify-content-center p-5">
+                  <Spinner animation="border" role="status">
+                    <span className="visually-hidden">Loading...</span>
+                  </Spinner>
+                </div>
+              ) : (
+                <Tab.Content>
+                  <Tab.Pane eventKey="media">
+                    <div className="d-flex flex-column align-items-center">
+                      <NewsFeed type="article" newsItems={newsItems ?? []} />
+                    </div>
+                  </Tab.Pane>
+                  <Tab.Pane eventKey="awards">
+                    <div className="d-flex flex-column align-items-center">
+                      <NewsFeed type="award" newsItems={newsItems ?? []} />
+                    </div>
+                  </Tab.Pane>
+                  <Tab.Pane eventKey="books">
+                    <div className="d-flex flex-column align-items-center">
+                      <NewsFeed type="book" newsItems={newsItems ?? []} />
+                    </div>
+                  </Tab.Pane>
+                </Tab.Content>
+              )}
             </Col>
           </Row>
         </Tab.Container>
@@ -79,7 +88,7 @@ export const InTheNews = () => {
   )
 }
 
-const TabGroup = ({ counts }: { counts: TabCounts }) => {
+const TabGroup = ({ counts }: { counts: TabCounts | null }) => {
   const { t } = useTranslation("inTheNews")
   return (
     <Row className="g-0 fs-4 fw-semibold">
@@ -89,7 +98,11 @@ const TabGroup = ({ counts }: { counts: TabCounts }) => {
             <Nav.Link eventKey="media">
               <div className="d-flex justify-content-center align-items-center gap-3 p-4">
                 {t("media.title")}
-                <Badge bg="secondary" className="rounded-pill px-4 fw-bold" style={{ fontSize: "20px" }}>{counts.media}</Badge>
+                <Badge bg="secondary" className="rounded-pill px-4 fw-bold"
+                  style={{ fontSize: "20px", visibility: counts ? "visible" : "hidden" }}
+                  >
+                  {counts ? counts.media : 0}
+                </Badge>
               </div>
             </Nav.Link>
           </Nav.Item>
@@ -101,7 +114,12 @@ const TabGroup = ({ counts }: { counts: TabCounts }) => {
             <Nav.Link eventKey="awards">
               <div className="d-flex justify-content-center align-items-center gap-3 p-4">
                 {t("awards.title")}
-                <Badge bg="secondary" className="rounded-pill px-4 fw-bold" style={{ fontSize: "20px" }}>{counts.awards}</Badge>
+                <Badge bg="secondary"
+                  className="rounded-pill px-4 fw-bold"
+                  style={{ fontSize: "20px", visibility: counts ? "visible" : "hidden" }}
+                  >
+                  {counts ? counts.awards : 0}
+                </Badge>
               </div>
             </Nav.Link>
           </Nav.Item>
@@ -113,7 +131,12 @@ const TabGroup = ({ counts }: { counts: TabCounts }) => {
             <Nav.Link eventKey="books">
               <div className="d-flex justify-content-center align-items-center gap-3 p-4">
                 {t("books.title")}
-                <Badge bg="secondary" className="rounded-pill px-4 fw-bold" style={{ fontSize: "20px" }}>{counts.books}</Badge>
+                <Badge bg="secondary"
+                  className="rounded-pill px-4 fw-bold"
+                  style={{ fontSize: "20px", visibility: counts ? "visible" : "hidden" }}
+                  >
+                  {counts ? counts.books : 0}
+                </Badge>
               </div>
             </Nav.Link>
           </Nav.Item>
@@ -123,7 +146,7 @@ const TabGroup = ({ counts }: { counts: TabCounts }) => {
   )
 }
 
-const TabDropdown = ({ counts }: { counts: TabCounts }) => {
+const TabDropdown = ({ counts }: { counts: TabCounts | null }) => {
   const { t } = useTranslation("inTheNews")
   const [selectedTab, setSelectedTab] = useState<string>("Media")
 

--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -37,17 +37,7 @@ const NewsFeed = ({
 export const InTheNews = () => {
   const { t } = useTranslation("inTheNews")
   const isMobile = useMediaQuery("(max-width: 768px)")
-  // const { result: newsItems = [] as NewsItem[] } = useNews()
-
-  const newsItems = [
-    { id: "1", title: "MAPLE Launches New Platform", url: "https://example.com/1", author: "Jane Smith", type: "article", publishDate: "2024-01-15", createdAt: null, description: "MAPLE has launched a new platform to enhance civic engagement and streamline public participation in government processes. MAPLE has launched a new platform to enhance civic engagement and streamline public participation in government processes." },
-    { id: "2", title: "Civic Tech Innovation Award", url: "https://example.com/2", author: "Award Committee", type: "award", publishDate: "2024-02-20", createdAt: null, description: "The Civic Tech Innovation Award recognizes outstanding contributions to the field of civic technology." },
-    { id: "3", title: "Democracy in the Digital Age", url: "https://example.com/3", author: "John Doe", type: "book", publishDate: "2024-03-10", createdAt: null, description: "A comprehensive look at how digital technologies are reshaping democratic processes." },
-    { id: "4", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
-    { id: "5", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
-    { id: "6", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
-    { id: "7", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
-  ] as unknown as NewsItem[]
+  const { result: newsItems = [] as NewsItem[] } = useNews()
 
 
   const counts: TabCounts = {

--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -5,39 +5,74 @@ import Nav from "react-bootstrap/Nav"
 import Dropdown from "react-bootstrap/Dropdown"
 import { useMediaQuery } from "usehooks-ts"
 import { useTranslation } from "next-i18next"
+import { NewsCard } from "./NewsCard"
+import { NewsType, NewsItem, useNews } from "components/db/news"
 
 
+type NewsFeedProps = {
+  type: NewsType
+  newsItems : NewsItem[]
+}
+
+const NewsFeed = ({
+  type,
+  newsItems
+}: NewsFeedProps) =>
+{
+  return (
+      <div className="d-flex flex-column align-items-left gap-1 w-100">
+        {newsItems.filter(item => item.type === type).map((item, index) => (
+          <NewsCard key={index} newsItem={item} />
+        ))}
+      </div>
+  )
+}
 
 export const InTheNews = () => {
   const { t } = useTranslation("inTheNews")
   const isMobile = useMediaQuery("(max-width: 768px)")
+  // const { result: newsItems = [] as NewsItem[] } = useNews()
+
+  const newsItems = [
+    { id: "1", title: "MAPLE Launches New Platform", url: "https://example.com/1", author: "Jane Smith", type: "article", publishDate: "2024-01-15", createdAt: null, description: "MAPLE has launched a new platform to enhance civic engagement and streamline public participation in government processes. MAPLE has launched a new platform to enhance civic engagement and streamline public participation in government processes." },
+    { id: "2", title: "Civic Tech Innovation Award", url: "https://example.com/2", author: "Award Committee", type: "award", publishDate: "2024-02-20", createdAt: null, description: "The Civic Tech Innovation Award recognizes outstanding contributions to the field of civic technology." },
+    { id: "3", title: "Democracy in the Digital Age", url: "https://example.com/3", author: "John Doe", type: "book", publishDate: "2024-03-10", createdAt: null, description: "A comprehensive look at how digital technologies are reshaping democratic processes." },
+    { id: "4", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
+    { id: "5", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
+    { id: "6", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
+    { id: "7", title: "The Engaged Citizen", url: "https://example.com/4", author: "Alice Brown", type: "book", publishDate: "2024-04-05", createdAt: null, description: "Exploring the role of active citizenship in modern democracies." },
+  ] as unknown as NewsItem[]
+
+
   return (
-    <Container className="ptx-4">
-      <h1 className="fw-bold m-5">{t("title")}</h1>
-      <Tab.Container defaultActiveKey="media">
-        {isMobile ? <TabDropdown /> : <TabGroup />}
-        <Row className="p-3 g-0">
-          <Col>
-            <Tab.Content>
-              <Tab.Pane eventKey="media">
-                <div className="d-flex flex-column align-items-center">
-                  <h2 className="mb-4">Media</h2>
-                </div>
-              </Tab.Pane>
-              <Tab.Pane eventKey="awards">
-                <div className="d-flex flex-column align-items-center">
-                  <h2 className="mb-4">Awards</h2>
-                </div>
-              </Tab.Pane>
-              <Tab.Pane eventKey="books">
-                <div className="d-flex flex-column align-items-center">
-                  <h2 className="mb-4">Books</h2>
-                </div>
-              </Tab.Pane>
-            </Tab.Content>
-          </Col>
-        </Row>
-      </Tab.Container>
+    <Container className="ptx-4 pt-5 gap-4">
+      <h1 className="fw-bold m-3">{t("title")}</h1>
+      <div className="bg-white rounded my-5">
+        <Tab.Container defaultActiveKey="media">
+          {isMobile ? <TabDropdown /> : <TabGroup />}
+          <Row className="p-3 g-0">
+            <Col>
+              <Tab.Content>
+                <Tab.Pane eventKey="media">
+                  <div className="d-flex flex-column align-items-center">
+                    <NewsFeed type="article" newsItems={newsItems} />
+                  </div>
+                </Tab.Pane>
+                <Tab.Pane eventKey="awards">
+                  <div className="d-flex flex-column align-items-center">
+                    <NewsFeed type="award" newsItems={newsItems} />
+                  </div>
+                </Tab.Pane>
+                <Tab.Pane eventKey="books">
+                  <div className="d-flex flex-column align-items-center">
+                    <NewsFeed type="book" newsItems={newsItems} />
+                  </div>
+                </Tab.Pane>
+              </Tab.Content>
+            </Col>
+          </Row>
+        </Tab.Container>
+      </div>
     </Container>
   )
 }
@@ -45,7 +80,7 @@ export const InTheNews = () => {
 const TabGroup = () => {
   const { t } = useTranslation("inTheNews")
   return (
-    <Row className="p-3 g-0">
+    <Row className="p-3 g-0 fs-4">
       <Col md={4} className="text-center">
         <Nav className="in-the-news flex-column">
           <Nav.Item>

--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react"
+import { Col, Row, Container } from "../bootstrap"
+import Tab from "react-bootstrap/Tab"
+import Nav from "react-bootstrap/Nav"
+import Dropdown from "react-bootstrap/Dropdown"
+import { useMediaQuery } from "usehooks-ts"
+import { useTranslation } from "next-i18next"
+
+export const InTheNews = () => {
+  const isMobile = useMediaQuery("(max-width: 768px)")
+  return (
+    <Container className="ptx-4">
+      <Tab.Container defaultActiveKey="media">
+        {isMobile ? <TabDropdown /> : <TabGroup />}
+        <Row className="p-3 g-0">
+          <Col>
+            <Tab.Content>
+              <Tab.Pane eventKey="media">
+                <div className="d-flex flex-column align-items-center">
+                  <h2 className="mb-4">Media</h2>
+                </div>
+              </Tab.Pane>
+              <Tab.Pane eventKey="awards">
+                <div className="d-flex flex-column align-items-center">
+                  <h2 className="mb-4">Awards</h2>
+                </div>
+              </Tab.Pane>
+              <Tab.Pane eventKey="books">
+                <div className="d-flex flex-column align-items-center">
+                  <h2 className="mb-4">Books</h2>
+                </div>
+              </Tab.Pane>
+            </Tab.Content>
+          </Col>
+        </Row>
+      </Tab.Container>
+    </Container>
+  )
+}
+
+const TabGroup = () => {
+  const { t } = useTranslation("inTheNews")
+  return (
+    <Row className="p-3 g-0">
+      <Col md={4} className="text-center">
+        <Nav className="our-team-tab flex-column">
+          <Nav.Item>
+            <Nav.Link eventKey="media">
+              {t("media.title")}
+            </Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Col>
+      <Col md={4} className="text-center">
+        <Nav className="our-team-tab flex-column">
+          <Nav.Item>
+            <Nav.Link eventKey="awards">{t("awards.title")}</Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Col>
+      <Col md={4} className="text-center">
+        <Nav className="our-team-tab flex-column">
+          <Nav.Item>
+            <Nav.Link eventKey="books">{t("books.title")}</Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Col>
+    </Row>
+  )
+}
+
+const TabDropdown = () => {
+  const { t } = useTranslation("inTheNews")
+  const [selectedTab, setSelectedTab] = useState<string>("Media")
+
+  const handleTabClick = (tabTitle: string) => {
+    setSelectedTab(tabTitle)
+  }
+
+  return (
+    <Row className="p-3 g-0">
+      <Col md={12}>
+        <Dropdown className="our-team-dropdown">
+          <Dropdown.Toggle className="our-team-dropdown-button">
+            <span style={{ float: "left" }}>{selectedTab}</span>
+          </Dropdown.Toggle>
+          <Dropdown.Menu className="p-2">
+            <Dropdown.Item
+              className="p-2"
+              eventKey="media"
+              onClick={() => handleTabClick("Media")}
+            >
+              {t("media.title")}
+            </Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item
+              className="p-2"
+              eventKey="awards"
+              onClick={() => handleTabClick("Awards")}
+            >
+              {t("awards.title")}
+            </Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item
+              className="p-2"
+              eventKey="books"
+              onClick={() => handleTabClick("Books")}
+            >
+              {t("books.title")}
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  )
+}

--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -6,10 +6,14 @@ import Dropdown from "react-bootstrap/Dropdown"
 import { useMediaQuery } from "usehooks-ts"
 import { useTranslation } from "next-i18next"
 
+
+
 export const InTheNews = () => {
+  const { t } = useTranslation("inTheNews")
   const isMobile = useMediaQuery("(max-width: 768px)")
   return (
     <Container className="ptx-4">
+      <h1 className="fw-bold m-5">{t("title")}</h1>
       <Tab.Container defaultActiveKey="media">
         {isMobile ? <TabDropdown /> : <TabGroup />}
         <Row className="p-3 g-0">
@@ -43,23 +47,21 @@ const TabGroup = () => {
   return (
     <Row className="p-3 g-0">
       <Col md={4} className="text-center">
-        <Nav className="our-team-tab flex-column">
+        <Nav className="in-the-news flex-column">
           <Nav.Item>
-            <Nav.Link eventKey="media">
-              {t("media.title")}
-            </Nav.Link>
+            <Nav.Link eventKey="media">{t("media.title")}</Nav.Link>
           </Nav.Item>
         </Nav>
       </Col>
       <Col md={4} className="text-center">
-        <Nav className="our-team-tab flex-column">
+        <Nav className="in-the-news flex-column">
           <Nav.Item>
             <Nav.Link eventKey="awards">{t("awards.title")}</Nav.Link>
           </Nav.Item>
         </Nav>
       </Col>
       <Col md={4} className="text-center">
-        <Nav className="our-team-tab flex-column">
+        <Nav className="in-the-news flex-column">
           <Nav.Item>
             <Nav.Link eventKey="books">{t("books.title")}</Nav.Link>
           </Nav.Item>

--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Col, Row, Container } from "../bootstrap"
+import { Col, Row, Container, Badge } from "../bootstrap"
 import Tab from "react-bootstrap/Tab"
 import Nav from "react-bootstrap/Nav"
 import Dropdown from "react-bootstrap/Dropdown"
@@ -11,7 +11,13 @@ import { NewsType, NewsItem, useNews } from "components/db/news"
 
 type NewsFeedProps = {
   type: NewsType
-  newsItems : NewsItem[]
+  newsItems: NewsItem[]
+}
+
+type TabCounts = {
+  media: number
+  awards: number
+  books: number
 }
 
 const NewsFeed = ({
@@ -44,13 +50,19 @@ export const InTheNews = () => {
   ] as unknown as NewsItem[]
 
 
+  const counts: TabCounts = {
+    media: newsItems.filter(item => item.type === "article").length,
+    awards: newsItems.filter(item => item.type === "award").length,
+    books: newsItems.filter(item => item.type === "book").length
+  }
+
   return (
-    <Container className="ptx-4 pt-5 gap-4">
-      <h1 className="fw-bold m-3">{t("title")}</h1>
-      <div className="bg-white rounded my-5">
+    <Container className="ptx-4 pt-5 gap-4 min-vh-100">
+      <h1 className="fw-bold m-3" style={{ fontSize: "5rem" }}>{t("title")}</h1>
+      <div className="d-flex flex-column bg-white rounded-4 my-5 gap-4 p-4">
         <Tab.Container defaultActiveKey="media">
-          {isMobile ? <TabDropdown /> : <TabGroup />}
-          <Row className="p-3 g-0">
+          {isMobile ? <TabDropdown counts={counts} /> : <TabGroup counts={counts} />}
+          <Row className="g-0">
             <Col>
               <Tab.Content>
                 <Tab.Pane eventKey="media">
@@ -77,28 +89,43 @@ export const InTheNews = () => {
   )
 }
 
-const TabGroup = () => {
+const TabGroup = ({ counts }: { counts: TabCounts }) => {
   const { t } = useTranslation("inTheNews")
   return (
-    <Row className="p-3 g-0 fs-4">
+    <Row className="g-0 fs-4 fw-semibold">
       <Col md={4} className="text-center">
         <Nav className="in-the-news flex-column">
           <Nav.Item>
-            <Nav.Link eventKey="media">{t("media.title")}</Nav.Link>
+            <Nav.Link eventKey="media">
+              <div className="d-flex justify-content-center align-items-center gap-3 p-4">
+                {t("media.title")}
+                <Badge bg="secondary" className="rounded-pill px-4 fw-bold" style={{ fontSize: "20px" }}>{counts.media}</Badge>
+              </div>
+            </Nav.Link>
           </Nav.Item>
         </Nav>
       </Col>
       <Col md={4} className="text-center">
         <Nav className="in-the-news flex-column">
           <Nav.Item>
-            <Nav.Link eventKey="awards">{t("awards.title")}</Nav.Link>
+            <Nav.Link eventKey="awards">
+              <div className="d-flex justify-content-center align-items-center gap-3 p-4">
+                {t("awards.title")}
+                <Badge bg="secondary" className="rounded-pill px-4 fw-bold" style={{ fontSize: "20px" }}>{counts.awards}</Badge>
+              </div>
+            </Nav.Link>
           </Nav.Item>
         </Nav>
       </Col>
       <Col md={4} className="text-center">
         <Nav className="in-the-news flex-column">
           <Nav.Item>
-            <Nav.Link eventKey="books">{t("books.title")}</Nav.Link>
+            <Nav.Link eventKey="books">
+              <div className="d-flex justify-content-center align-items-center gap-3 p-4">
+                {t("books.title")}
+                <Badge bg="secondary" className="rounded-pill px-4 fw-bold" style={{ fontSize: "20px" }}>{counts.books}</Badge>
+              </div>
+            </Nav.Link>
           </Nav.Item>
         </Nav>
       </Col>
@@ -106,7 +133,7 @@ const TabGroup = () => {
   )
 }
 
-const TabDropdown = () => {
+const TabDropdown = ({ counts }: { counts: TabCounts }) => {
   const { t } = useTranslation("inTheNews")
   const [selectedTab, setSelectedTab] = useState<string>("Media")
 

--- a/components/InTheNews/InTheNews.tsx
+++ b/components/InTheNews/InTheNews.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from "next-i18next"
 import { NewsCard } from "./NewsCard"
 import { NewsType, NewsItem, useNews } from "components/db/news"
 
-
 type NewsFeedProps = {
   type: NewsType
   newsItems: NewsItem[]
@@ -20,17 +19,15 @@ type TabCounts = {
   books: number
 }
 
-const NewsFeed = ({
-  type,
-  newsItems
-}: NewsFeedProps) =>
-{
+const NewsFeed = ({ type, newsItems }: NewsFeedProps) => {
   return (
-      <div className="d-flex flex-column align-items-left gap-1 w-100">
-        {newsItems.filter(item => item.type === type).map((item, index) => (
+    <div className="d-flex flex-column align-items-left gap-1 w-100">
+      {newsItems
+        .filter(item => item.type === type)
+        .map((item, index) => (
           <NewsCard key={index} newsItem={item} />
         ))}
-      </div>
+    </div>
   )
 }
 
@@ -49,10 +46,16 @@ export const InTheNews = () => {
 
   return (
     <Container className="ptx-4 pt-5 gap-4 min-vh-100">
-      <h1 className="fw-bold m-3" style={{ fontSize: "5rem" }}>{t("title")}</h1>
+      <h1 className="fw-bold m-3" style={{ fontSize: "5rem" }}>
+        {t("title")}
+      </h1>
       <div className="d-flex flex-column bg-white rounded-4 my-5 gap-4 p-4">
         <Tab.Container defaultActiveKey="media">
-          {isMobile ? <TabDropdown counts={counts} /> : <TabGroup counts={counts} />}
+          {isMobile ? (
+            <TabDropdown counts={counts} />
+          ) : (
+            <TabGroup counts={counts} />
+          )}
           <Row className="g-0">
             <Col>
               {loading ? (
@@ -98,9 +101,14 @@ const TabGroup = ({ counts }: { counts: TabCounts | null }) => {
             <Nav.Link eventKey="media">
               <div className="d-flex justify-content-center align-items-center gap-3 p-4">
                 {t("media.title")}
-                <Badge bg="secondary" className="rounded-pill px-4 fw-bold"
-                  style={{ fontSize: "20px", visibility: counts ? "visible" : "hidden" }}
-                  >
+                <Badge
+                  bg="secondary"
+                  className="rounded-pill px-4 fw-bold"
+                  style={{
+                    fontSize: "20px",
+                    visibility: counts ? "visible" : "hidden"
+                  }}
+                >
                   {counts ? counts.media : 0}
                 </Badge>
               </div>
@@ -114,10 +122,14 @@ const TabGroup = ({ counts }: { counts: TabCounts | null }) => {
             <Nav.Link eventKey="awards">
               <div className="d-flex justify-content-center align-items-center gap-3 p-4">
                 {t("awards.title")}
-                <Badge bg="secondary"
+                <Badge
+                  bg="secondary"
                   className="rounded-pill px-4 fw-bold"
-                  style={{ fontSize: "20px", visibility: counts ? "visible" : "hidden" }}
-                  >
+                  style={{
+                    fontSize: "20px",
+                    visibility: counts ? "visible" : "hidden"
+                  }}
+                >
                   {counts ? counts.awards : 0}
                 </Badge>
               </div>
@@ -131,10 +143,14 @@ const TabGroup = ({ counts }: { counts: TabCounts | null }) => {
             <Nav.Link eventKey="books">
               <div className="d-flex justify-content-center align-items-center gap-3 p-4">
                 {t("books.title")}
-                <Badge bg="secondary"
+                <Badge
+                  bg="secondary"
                   className="rounded-pill px-4 fw-bold"
-                  style={{ fontSize: "20px", visibility: counts ? "visible" : "hidden" }}
-                  >
+                  style={{
+                    fontSize: "20px",
+                    visibility: counts ? "visible" : "hidden"
+                  }}
+                >
                   {counts ? counts.books : 0}
                 </Badge>
               </div>

--- a/components/InTheNews/NewsCard.tsx
+++ b/components/InTheNews/NewsCard.tsx
@@ -3,46 +3,65 @@ import { NewsItem } from "components/db"
 import { Col, Row, Stack } from "../bootstrap"
 
 type NewsCardProps = {
-  newsItem : NewsItem
+  newsItem: NewsItem
 }
 
-export const NewsCard = ({
-  newsItem
-}: NewsCardProps) => {
+export const NewsCard = ({ newsItem }: NewsCardProps) => {
   return (
-  <div className="d-flex flex-row flex-fill gap-5 p-4" style={{ backgroundColor: "#F6F7FF", borderTop: "6px solid var(--bs-secondary)" }}>
-    <div className="d-flex flex-fill flex-column gap-2" style={{ minWidth: 0 }}>
-      <div className="d-flex flex-row align-items-center gap-4 mb-1">
-        <p className="m-0 fw-medium">
-          {new Date(newsItem.publishDate).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
-        </p>
-        <div style={{ width: "1px", height: "1em", backgroundColor: "black", alignSelf: "center" }} />
-        <p className="m-0">{newsItem.author}</p>
+    <div
+      className="d-flex flex-row flex-fill gap-5 p-4"
+      style={{
+        backgroundColor: "#F6F7FF",
+        borderTop: "6px solid var(--bs-secondary)"
+      }}
+    >
+      <div
+        className="d-flex flex-fill flex-column gap-2"
+        style={{ minWidth: 0 }}
+      >
+        <div className="d-flex flex-row align-items-center gap-4 mb-1">
+          <p className="m-0 fw-medium">
+            {new Date(newsItem.publishDate).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+              timeZone: "UTC"
+            })}
+          </p>
+          <div
+            style={{
+              width: "1px",
+              height: "1em",
+              backgroundColor: "black",
+              alignSelf: "center"
+            }}
+          />
+          <p className="m-0">{newsItem.author}</p>
+        </div>
+        <div className="">
+          <a
+            className="fw-bold fs-4 lh-1 tracking-tight text-decoration-underline"
+            href={newsItem.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {newsItem.title}
+          </a>
+        </div>
+        <div className="text-truncate">{newsItem.description}</div>
       </div>
-      <div className="">
-        <a className="fw-bold fs-4 lh-1 tracking-tight text-decoration-underline"
-          href={newsItem.url} 
+      <div className="align-self-end flex-shrink-0">
+        <a
+          className="d-flex gap-1 text-decoration-none hover-underline"
+          href={newsItem.url}
           target="_blank"
           rel="noopener noreferrer"
-          >
-          {newsItem.title}
+          style={{ color: "#1587D3", fontWeight: 800 }}
+        >
+          READ MORE
+          <ArrowForward />
         </a>
       </div>
-      <div className="text-truncate">
-        {newsItem.description}
-      </div>
     </div>
-    <div className="align-self-end flex-shrink-0">
-      <a className="d-flex gap-1 text-decoration-none hover-underline"
-        href={newsItem.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: "#1587D3", fontWeight: 800 }}
-        >
-        READ MORE
-        <ArrowForward />
-      </a>
-    </div>
-  </div>
   )
 }

--- a/components/InTheNews/NewsCard.tsx
+++ b/components/InTheNews/NewsCard.tsx
@@ -1,12 +1,13 @@
 import ArrowForward from "@mui/icons-material/ArrowForward"
+import { useTranslation } from "next-i18next"
 import { NewsItem } from "components/db"
-import { Col, Row, Stack } from "../bootstrap"
 
 type NewsCardProps = {
   newsItem: NewsItem
 }
 
 export const NewsCard = ({ newsItem }: NewsCardProps) => {
+  const { t } = useTranslation("inTheNews")
   return (
     <div
       className="d-flex flex-row flex-fill gap-5 p-4"
@@ -58,7 +59,7 @@ export const NewsCard = ({ newsItem }: NewsCardProps) => {
           rel="noopener noreferrer"
           style={{ color: "#1587D3", fontWeight: 800 }}
         >
-          READ MORE
+          {t("readMoreButton")}
           <ArrowForward />
         </a>
       </div>

--- a/components/InTheNews/NewsCard.tsx
+++ b/components/InTheNews/NewsCard.tsx
@@ -1,0 +1,48 @@
+import ArrowForward from "@mui/icons-material/ArrowForward"
+import { NewsItem } from "components/db"
+import { Col, Row, Stack } from "../bootstrap"
+
+type NewsCardProps = {
+  newsItem : NewsItem
+}
+
+export const NewsCard = ({
+  newsItem
+}: NewsCardProps) => {
+  return (
+  <div className="d-flex flex-row flex-fill gap-5 p-4" style={{ backgroundColor: "#F6F7FF", borderTop: "6px solid var(--bs-secondary)" }}>
+    <div className="d-flex flex-fill flex-column gap-2" style={{ minWidth: 0 }}>
+      <div className="d-flex flex-row align-items-center gap-4 mb-1">
+        <p className="m-0 fw-medium">
+          {new Date(newsItem.publishDate).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
+        </p>
+        <div style={{ width: "1px", height: "1em", backgroundColor: "black", alignSelf: "center" }} />
+        <p className="m-0">{newsItem.author}</p>
+      </div>
+      <div className="">
+        <a className="fw-bold fs-4 lh-1 tracking-tight text-decoration-underline"
+          href={newsItem.url} 
+          target="_blank"
+          rel="noopener noreferrer"
+          >
+          {newsItem.title}
+        </a>
+      </div>
+      <div className="text-truncate">
+        {newsItem.description}
+      </div>
+    </div>
+    <div className="align-self-end flex-shrink-0">
+      <a className="d-flex gap-1 text-decoration-none hover-underline"
+        href={newsItem.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: "#1587D3", fontWeight: 800 }}
+        >
+        READ MORE
+        <ArrowForward />
+      </a>
+    </div>
+  </div>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -88,12 +88,12 @@ const MobileNav: React.FC<React.PropsWithChildren<unknown>> = () => {
         <NavbarLinkTestimony handleClick={closeNav} />
         {authenticated ? <NavbarLinkNewsfeed handleClick={closeNav} /> : <></>}
         <NavDropdown className={"navLink-primary"} title={t("about")}>
-           <NavbarLinkGoals handleClick={closeNav} />
-           <NavbarLinkTeam handleClick={closeNav} />
-           <NavbarLinkSupport handleClick={closeNav} />
-           <NavbarLinkFAQ handleClick={closeNav} />
-           <NavbarLinkAI handleClick={closeNav} />
-           <NavbarLinkInTheNews handleClick={closeNav} />
+          <NavbarLinkGoals handleClick={closeNav} />
+          <NavbarLinkTeam handleClick={closeNav} />
+          <NavbarLinkSupport handleClick={closeNav} />
+          <NavbarLinkFAQ handleClick={closeNav} />
+          <NavbarLinkAI handleClick={closeNav} />
+          <NavbarLinkInTheNews handleClick={closeNav} />
         </NavDropdown>
 
         <NavDropdown className={"navLink-primary"} title={t("learn")}>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,6 +16,7 @@ import {
   NavbarLinkEffective,
   NavbarLinkFAQ,
   NavbarLinkGoals,
+  NavbarLinkInTheNews,
   NavbarLinkLogo,
   NavbarLinkNewsfeed,
   NavbarLinkProcess,
@@ -87,11 +88,12 @@ const MobileNav: React.FC<React.PropsWithChildren<unknown>> = () => {
         <NavbarLinkTestimony handleClick={closeNav} />
         {authenticated ? <NavbarLinkNewsfeed handleClick={closeNav} /> : <></>}
         <NavDropdown className={"navLink-primary"} title={t("about")}>
-          <NavbarLinkGoals handleClick={closeNav} />
-          <NavbarLinkTeam handleClick={closeNav} />
-          <NavbarLinkSupport handleClick={closeNav} />
-          <NavbarLinkFAQ handleClick={closeNav} />
-          <NavbarLinkAI handleClick={closeNav} />
+           <NavbarLinkGoals handleClick={closeNav} />
+           <NavbarLinkTeam handleClick={closeNav} />
+           <NavbarLinkSupport handleClick={closeNav} />
+           <NavbarLinkFAQ handleClick={closeNav} />
+           <NavbarLinkAI handleClick={closeNav} />
+           <NavbarLinkInTheNews handleClick={closeNav} />
         </NavDropdown>
 
         <NavDropdown className={"navLink-primary"} title={t("learn")}>
@@ -228,6 +230,7 @@ const DesktopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
             <NavbarLinkSupport />
             <NavbarLinkFAQ />
             <NavbarLinkAI />
+            <NavbarLinkInTheNews />
           </Dropdown.Menu>
         </Dropdown>
       </div>

--- a/components/NavbarComponents.tsx
+++ b/components/NavbarComponents.tsx
@@ -378,3 +378,24 @@ export const NavbarLinkWhyUse: React.FC<
     </NavDropdown.Item>
   )
 }
+
+export const NavbarLinkInTheNews: React.FC<
+  React.PropsWithChildren<{
+    handleClick?: any
+    other?: any
+  }>
+> = ({ handleClick, other }) => {
+  const isMobile = useMediaQuery("(max-width: 768px)")
+  const { t } = useTranslation(["common", "auth"])
+  return (
+    <NavDropdown.Item onClick={handleClick}>
+      <NavLink
+        className={isMobile ? "navLink-primary" : ""}
+        href="/about/in-the-news"
+        {...other}
+      >
+        {t("navigation.inTheNews")}
+      </NavLink>
+    </NavDropdown.Item>
+  )
+}

--- a/components/db/news.ts
+++ b/components/db/news.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, orderBy, Timestamp } from "firebase/firestore"
+import { collection, getDocs, orderBy, query, Timestamp } from "firebase/firestore"
 import { useAsync } from "react-async-hook"
 import { firestore } from "../firebase"
 
@@ -17,7 +17,8 @@ export type NewsItem = {
 
 export async function listNews(): Promise<NewsItem[]> {
   const newsRef = collection(firestore, "news")
-  const result = await getDocs(newsRef)
+  const q = query(newsRef, orderBy("publishDate", "desc"))
+  const result = await getDocs(q)
   return result.docs.map(d => ({ id: d.id, ...d.data() } as NewsItem))
 }
 

--- a/components/db/news.ts
+++ b/components/db/news.ts
@@ -1,4 +1,10 @@
-import { collection, getDocs, orderBy, query, Timestamp } from "firebase/firestore"
+import {
+  collection,
+  getDocs,
+  orderBy,
+  query,
+  Timestamp
+} from "firebase/firestore"
 import { useAsync } from "react-async-hook"
 import { firestore } from "../firebase"
 

--- a/pages/about/in-the-news.tsx
+++ b/pages/about/in-the-news.tsx
@@ -1,0 +1,17 @@
+import { createPage } from "../../components/page"
+import { InTheNews } from "../../components/InTheNews/InTheNews"
+import { createGetStaticTranslationProps } from "components/translations"
+
+export default createPage({
+  titleI18nKey: "titles.in_the_news",
+  Page: () => {
+    return <InTheNews />
+  }
+})
+
+export const getStaticProps = createGetStaticTranslationProps([
+  "auth",
+  "common",
+  "footer",
+  "inTheNews"
+])

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -128,6 +128,7 @@
     "aboutTestimony": "About Testimony",
     "viewProfile": "View Profile",
     "whyUseMaple": "Why Use MAPLE",
+    "inTheNews": "In The News",
     "login": "Login"
   },
   "new_feature": "*NEW*",
@@ -180,6 +181,7 @@
     "legislative_process": "How To Have Impact Through Legislative Testimony",
     "submit_testimony": "Submit Testimony",
     "support_maple": "How to Support MAPLE",
+    "in_the_news": "In The News",
     "testimony": "Testimony",
     "policies": "Policies",
     "unsubscribe": "Unsubscribe",

--- a/public/locales/en/inTheNews.json
+++ b/public/locales/en/inTheNews.json
@@ -1,0 +1,12 @@
+{
+  "title": "Media, Articles & Insights",
+  "media": {
+    "title": "Media"
+  },
+  "awards": {
+    "title": "Awards"
+  },
+  "books": {
+    "title": "Books"
+  }
+}

--- a/public/locales/en/inTheNews.json
+++ b/public/locales/en/inTheNews.json
@@ -1,5 +1,6 @@
 {
   "title": "Media, Articles & Insights",
+  "readMoreButton": "READ MORE",
   "media": {
     "title": "Media"
   },

--- a/styles/bootstrap.scss
+++ b/styles/bootstrap.scss
@@ -149,3 +149,9 @@ $utilities: (
 .tracking-widest {
   letter-spacing: 0.1em;
 }
+
+.hover-underline {
+  &:hover {
+    text-decoration: underline !important;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -159,3 +159,18 @@
   letter-spacing: 0.015em;
   padding: 7px, 8px, 7px, 8px;
 }
+
+/* Custom style in "In The News" Page */
+.in-the-news .nav-item .nav-link {
+  color: black;
+  font-weight: 600;
+  border-bottom: 3px solid;
+  border-color: #0000001a;
+}
+.in-the-news .nav-item .nav-link:hover {
+  color: #15276A;
+}
+.in-the-news .nav-item .nav-link.active {
+  color: #15276A;
+  border-color: #15276A;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -164,7 +164,7 @@
 .in-the-news .nav-item .nav-link {
   color: black;
   font-weight: 600;
-  border-bottom: 3px solid;
+  border-bottom: 2px solid;
   border-color: #0000001a;
 }
 .in-the-news .nav-item .nav-link:hover {
@@ -172,5 +172,6 @@
 }
 .in-the-news .nav-item .nav-link.active {
   color: #15276A;
+  border-bottom: 4px solid;
   border-color: #15276A;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -168,10 +168,10 @@
   border-color: #0000001a;
 }
 .in-the-news .nav-item .nav-link:hover {
-  color: #15276A;
+  color: #15276a;
 }
 .in-the-news .nav-item .nav-link.active {
-  color: #15276A;
+  color: #15276a;
   border-bottom: 4px solid;
-  border-color: #15276A;
+  border-color: #15276a;
 }


### PR DESCRIPTION
# Summary

Implements the in the news page as described in issue #2045 


# Checklist

- [X] On the frontend, I've made my strings translate-able.
- [X] If I've added shared components, I've added a storybook story.
- [X] I've made pages responsive and look good on mobile.
- [X] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Testing Guide
- Navigate to Admin "In The News" section
- Create one or more news items
- Navigate to `/about/in-the-news` to view the results

# Screenshots

<img width="2544" height="1275" alt="image" src="https://github.com/user-attachments/assets/9349564b-643f-4d2a-ad6d-833a8c09894f" />

