### PR TITLE
Fix Loading State in Newsfeed

### DIFF
--- a/components/Newsfeed/Newsfeed.tsx
+++ b/components/Newsfeed/Newsfeed.tsx
@@ -2,7 +2,7 @@ import ErrorPage from "next/error"
 import { flags } from "../featureFlags"
 import { Timestamp } from "firebase/firestore"
 import { useTranslation } from "next-i18next"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Frequency, useAuth } from "../auth"
 import { Col, Row, Spinner } from "../bootstrap"
 import { Profile, useProfile, usePublicProfile } from "../db"
@@ -33,19 +33,17 @@ export default function Newsfeed() {
     useState<boolean>(true)
 
   const [allResults, setAllResults] = useState<Notifications>([])
-  const [filteredResults, setFilteredResults] = useState<Notifications>([])
+  const [notificationsLoading, setNotificationsLoading] = useState(true)
 
-  useEffect(() => {
-    const results = allResults.filter(result => {
-      if (isShowingOrgs && result.type == `testimony`) return true
-      if (isShowingBills && result.type == `bill`) return true
-      if (isShowingBallotQuestions && result.type == `ballotQuestion`)
+  const filteredResults = useMemo(() => {
+    return allResults.filter(result => {
+      if (isShowingOrgs && result.type === "testimony") return true
+      if (isShowingBills && result.type === "bill") return true
+      if (isShowingBallotQuestions && result.type == "ballotQuestion")
         return true
       return false
     })
-
-    setFilteredResults(results)
-  }, [isShowingOrgs, isShowingBills, isShowingBallotQuestions, allResults])
+  }, [allResults, isShowingOrgs, isShowingBallotQuestions, isShowingBills])
 
   const onOrgFilterChange = (isShowing: boolean) => {
     setIsShowingOrgs(isShowing)
@@ -65,12 +63,14 @@ export default function Newsfeed() {
         if (uid) {
           const notifications = await notificationQuery(uid)
           setAllResults(notifications)
-          setFilteredResults(notifications)
         }
       } catch (error) {
         console.error("Error fetching notifications: " + error)
+      } finally {
+        setNotificationsLoading(false)
       }
     }
+    setNotificationsLoading(true)
     fetchNotifications()
   }, [uid])
 
@@ -223,7 +223,7 @@ export default function Newsfeed() {
 
   return (
     <>
-      {result.loading && uid ? (
+      {(uid && result.loading) || notificationsLoading ? (
         <Row>
           <Spinner animation="border" className="mx-auto" />
         </Row>


### PR DESCRIPTION
# Summary

Expands the loading state logic for the NewsFeed page such that it now waits for both the user's profile to be resolved *and* the latest notifications to be fetched and filtered, before attempting to display the main content.

Addresses issue #2099 

This means:
- adding a new loading state to track the status of fetching the latest notifications
- moving filtering out of a useEffect into a useMemo

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Steps to test/reproduce

Log in as a user who has notifications on their NewsFeed. (or manufacture notification on their news feed)
Refresh the page and observe / add logging statements and verify that the "noResults" version of the component never appears when it shouldn't.