### PR TITLE
Remove noisy progress logs from audio processor

### DIFF
--- a/functions/src/events/scrapeEvents.ts
+++ b/functions/src/events/scrapeEvents.ts
@@ -166,15 +166,6 @@ const extractAudioFromVideo = async (
       .on("start", commandLine => {
         console.log(`Spawned FFmpeg with command: ${commandLine}`)
       })
-      .on("progress", progress => {
-        if (
-          progress &&
-          progress.percent &&
-          Math.round(progress.percent) % 10 === 0
-        ) {
-          console.log(`Processing: ${progress.percent}% done`)
-        }
-      })
       .on("end", () => {
         console.log("FFmpeg processing finished successfully")
         resolve()


### PR DESCRIPTION
I don't think we really need these anymore - they're a bit buggy since we get a bunch of log lines whenever the progress rounds to ~10%, and the start/end confirmation is all we really need at the point in the dev cycle. 