### PR TITLE
Bug fixes to direct users to email verification before submitting testimony

### DIFF
--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -129,7 +129,10 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
     setFollowStatus(prev => ({ ...prev, [topicName]: false }))
   }
 
+  const { t } = useTranslation("testimony")
+
   const isFollowing = followStatus[topicName]
+  const isUnverified = !!user && !isUser && !user.emailVerified
   const text = isFollowing ? "Unfollow" : "Follow"
   const checkmark = isFollowing ? (
     <StyledImage src="/check-white.svg" alt="" />
@@ -159,12 +162,18 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
     items.push(
       <PolicyActionItem
         key="add-testimony"
-        billName={`${isUser ? "Edit" : "Add"} Testimony for ${policyLabel}`}
-        href={formUrl(bill.id, bill.court, "position", ballotQuestionId)}
+        billName={
+          isUnverified
+            ? t("panel.unverifiedEmail.title")
+            : `${isUser ? "Edit" : "Add"} Testimony for ${policyLabel}`
+        }
+        href={
+          isUnverified
+            ? `/profile?id=${uid}`
+            : formUrl(bill.id, bill.court, "position", ballotQuestionId)
+        }
       />
     )
-
-  const { t } = useTranslation("testimony")
 
   return (
     <Card

--- a/pages/submit-testimony.tsx
+++ b/pages/submit-testimony.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useRouter } from "next/router"
-import { requireAuth } from "../components/auth"
+import { requireAuth, useAuth } from "../components/auth"
 import { isActiveBallotQuestionPhase } from "../components/ballotquestions/status"
 import { dbService } from "../components/db"
 import { createPage } from "../components/page"
@@ -18,10 +18,16 @@ export default createPage({
 
 function SubmitTestimonyPage() {
   const router = useRouter()
+  const { user } = useAuth()
   const [isAllowed, setIsAllowed] = useState(false)
 
   useEffect(() => {
     if (!router.isReady) return
+
+    if (user && !user.emailVerified) {
+      void router.replace(`/profile?id=${user.uid}`)
+      return
+    }
 
     const ballotQuestionId =
       typeof router.query.ballotQuestionId === "string"
@@ -62,7 +68,7 @@ function SubmitTestimonyPage() {
     return () => {
       active = false
     }
-  }, [router])
+  }, [router, user])
 
   if (!isAllowed) return null
 


### PR DESCRIPTION
# Summary

Two  bugfixes addressing issue #2057 
1. Added a check to the "Add Testimony" button on the Testimony Detail page so that users who have not verified their email will be asked to “verify email to add testimony”, and then led to their profile page upon clicking the button. 
2. Added a redirect from the Submit Testimony page to the Profile Page for users that are not email verified


# Checklist

- [ Yes ] On the frontend, I've made my strings translate-able.
- [ N/A ] If I've added shared components, I've added a storybook story.
- [ N/A ] I've made pages responsive and look good on mobile.
- [N/A ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots
<img width="802" height="560" alt="VerifyEmailToAddTestimony" src="https://github.com/user-attachments/assets/cebfb277-ae43-4795-bd26-eb58f7fa90b5" />

# Steps to test/reproduce

A. Test for user without email verification:
     1. Create a new user but do not verify their email.
     2. Navigate to a particular testimony. [Example](https://maple-dev.vercel.app/testimony/norht--9nrCzL34sDQa5J/1)
     3. Confirm that button on the right says "Verify Your Email to Add Testimony for <specific bill>"
     4. Click that button and confirm it takes you to the profile page where the verify account section is visible. 
     5. Paste a submit testimony page directly into the URL and confirm you are redirected to your profile page. [Example](https://maple-dev.vercel.app/submit-testimony?billId=H5010&court=194&step=position): 

B. Test for user with email verification (Behavior unchanged from current state. Confirming no regression):
     1. Create a new user and verify their email.
     2. Navigate to a particular testimony. [Example](https://maple-dev.vercel.app/testimony/norht--9nrCzL34sDQa5J/1)
     3. Confirm that button on the right says "Add Testimony for <specific bill>"
     4. Click that button and confirm it takes you to the Sumit Testimony page.
     5. Confirm that he Sumit Testimony page loads as expected.
     
C. Test for user not logged in (Behavior unchanged from current state. Confirming no regression):
     1. Log out
     2. Navigate to a particular testimony. [Example](https://maple-dev.vercel.app/testimony/norht--9nrCzL34sDQa5J/1)
     3. Confirm that button on the right says "Add Testimony for <specific bill>"
     4. Click that button and confirm it takes you to the login / signup page.
