### PR TITLE
Fix Bill History Scraper

### DIFF
--- a/components/bill/HistoryTable.tsx
+++ b/components/bill/HistoryTable.tsx
@@ -37,7 +37,9 @@ const BillHistoryActionRows = ({ billHistory }: HistoryProps) => {
         return (
           <tr key={index}>
             <td>
-              {Date.substring(5, 10)}-{Date.substring(0, 4)}
+              {Date
+                ? `${Date.substring(5, 10)}-${Date.substring(0, 4)}`
+                : ""}
             </td>
             <td>
               <LinkConnectedBills action={Action} />

--- a/components/bill/HistoryTable.tsx
+++ b/components/bill/HistoryTable.tsx
@@ -37,9 +37,7 @@ const BillHistoryActionRows = ({ billHistory }: HistoryProps) => {
         return (
           <tr key={index}>
             <td>
-              {Date
-                ? `${Date.substring(5, 10)}-${Date.substring(0, 4)}`
-                : ""}
+              {Date ? `${Date.substring(5, 10)}-${Date.substring(0, 4)}` : ""}
             </td>
             <td>
               <LinkConnectedBills action={Action} />

--- a/components/bill/Status.tsx
+++ b/components/bill/Status.tsx
@@ -38,14 +38,8 @@ export const Status = ({ bill }: BillProps) => {
     hearingCheck = true
   }
 
-  let hearingDate = ""
-  if (history?.Date) {
-    hearingDate = history.Date
-  }
-  let dateCheck = false
-  if (hearingDate < today) {
-    dateCheck = true
-  }
+  const hearingDate = history?.Date ?? ""
+  const dateCheck = !!hearingDate && hearingDate < today
 
   if (!history) return null
   return (

--- a/functions/src/bills/types.ts
+++ b/functions/src/bills/types.ts
@@ -19,7 +19,7 @@ export const BillReference = Record({
 
 export type BillHistoryAction = Static<typeof BillHistoryAction>
 export const BillHistoryAction = Record({
-  Date: String,
+  Date: Nullable(String),
   Branch: String,
   Action: String
 })


### PR DESCRIPTION
# Summary

Fixes a bug where billHistory items with null dates ( some of which were present in bills from session 194 ) would fail to be ingested and possibly crash the entire scraper batch.
Addresses issue #2120 

# Steps to test/reproduce

Running the scrapers should no longer produce errors that look like the following:
```
  ⚠  functions: ValidationError: Validation failed:                                                                                                               
  [
    {                                                                                                                                                             
      "Date": "Expected string, but was null"
    }                                                                                                                                                             
  ].                                     
  Object should match { Date: string; Branch: string; Action: string; }[]                                                                                         
      at new ValidationError (/app/functions/node_modules/runtypes/lib/errors.js:22:28)                                                                           
      at Object.check (/app/functions/node_modules/runtypes/lib/runtype.js:37:19)                                                                                 
      at Object.getBillHistory (/app/functions/lib/malegislature.js:146:32)                                                                                       
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                               
      at async fetchResource (/app/functions/lib/bills/bills.js:44:25)                                                                                            
      at async /app/functions/lib/scraper.js:85:34                                                                                                                
      at async runFunction (/app/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:506:9)                                                      
      at async runBackground (/app/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:507:9)                                                    
  ⚠  Your function was killed because it raised an unhandled error.
  ```
