### PR TITLE
Mock Firebase in Storybook

### DIFF
--- a/.storybook/firebase-guards/auth.guard.js
+++ b/.storybook/firebase-guards/auth.guard.js
@@ -1,0 +1,118 @@
+const authModule = require("@firebase/auth")
+const {
+  getStorybookAuthState,
+  setStorybookAuthState,
+  shouldAllowFirebaseCall,
+  throwBlockedFirebaseCall
+} = require("./common")
+
+function emitAuthState(callback) {
+  const { user } = getStorybookAuthState()
+  callback(user)
+}
+
+function block(apiName) {
+  return () => {
+    throwBlockedFirebaseCall(
+      "auth",
+      apiName,
+      "Mock auth state in your story providers or pass explicit props that avoid auth hooks."
+    )
+  }
+}
+
+function onAuthStateChanged(auth, nextOrObserver, error, completed) {
+  if (shouldAllowFirebaseCall()) {
+    return authModule.onAuthStateChanged(auth, nextOrObserver, error, completed)
+  }
+
+  const callback =
+    typeof nextOrObserver === "function"
+      ? nextOrObserver
+      : nextOrObserver?.next ?? (() => undefined)
+
+  emitAuthState(callback)
+
+  return () => undefined
+}
+
+function patchAuthInstance(auth) {
+  if (!auth || shouldAllowFirebaseCall()) return auth
+
+  return new Proxy(auth, {
+    get(target, prop, receiver) {
+      if (prop === "onAuthStateChanged") {
+        return onAuthStateChanged
+      }
+      return Reflect.get(target, prop, receiver)
+    }
+  })
+}
+
+function getAuth(...args) {
+  const auth = authModule.getAuth(...args)
+  return patchAuthInstance(auth)
+}
+
+function initializeAuth(...args) {
+  const auth = authModule.initializeAuth(...args)
+  return patchAuthInstance(auth)
+}
+
+module.exports = {
+  ...authModule,
+  getAuth,
+  initializeAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword: block("signInWithEmailAndPassword"),
+  signInWithPopup: block("signInWithPopup"),
+  signInWithRedirect: block("signInWithRedirect"),
+  signInAnonymously: block("signInAnonymously"),
+  mockLoggedOutAuthState() {
+    return setStorybookAuthState({ user: null })
+  },
+  mockLoggedInUserAuthState(overrides = {}) {
+    const user = {
+      uid: "storybook-user",
+      email: "storybook-user@example.com",
+      emailVerified: true,
+      displayName: "Storybook User",
+      isAnonymous: false,
+      providerId: "firebase",
+      photoURL: null,
+      phoneNumber: null,
+      tenantId: null,
+      metadata: {
+        creationTime: "",
+        lastSignInTime: ""
+      },
+      providerData: [],
+      refreshToken: "storybook-refresh-token",
+      stsTokenManager: {
+        accessToken: "storybook-access-token",
+        refreshToken: "storybook-refresh-token",
+        expirationTime: Date.now() + 60 * 60 * 1000
+      },
+      getIdToken: async () => "storybook-id-token",
+      getIdTokenResult: async () => ({
+        token: "storybook-id-token",
+        authTime: "",
+        issuedAtTime: "",
+        expirationTime: "",
+        signInProvider: null,
+        claims: {
+          role: "user",
+          email_verified: true
+        }
+      }),
+      reload: async () => undefined,
+      delete: async () => undefined,
+      toJSON: () => ({})
+    }
+
+    return setStorybookAuthState({
+      user: { ...user, ...overrides },
+      claims: { role: "user", email_verified: true }
+    })
+  }
+}

--- a/.storybook/firebase-guards/common.js
+++ b/.storybook/firebase-guards/common.js
@@ -1,0 +1,68 @@
+const ALLOW_FLAG = "__MAPLE_STORYBOOK_ALLOW_FIREBASE__"
+const WARNED_FLAG = "__MAPLE_STORYBOOK_FIREBASE_WARNED__"
+const AUTH_STATE_KEY = "__MAPLE_STORYBOOK_FIREBASE_AUTH_STATE__"
+
+function canAllowInRuntime() {
+  if (typeof globalThis !== "undefined") {
+    return Boolean(globalThis[ALLOW_FLAG])
+  }
+  return false
+}
+
+function canAllowFromEnv() {
+  return process.env.STORYBOOK_ALLOW_FIREBASE_CALLS === "1"
+}
+
+function shouldAllowFirebaseCall() {
+  return canAllowFromEnv() || canAllowInRuntime()
+}
+
+function warnOnce(key, message) {
+  if (typeof globalThis === "undefined") return
+
+  if (!globalThis[WARNED_FLAG]) {
+    globalThis[WARNED_FLAG] = new Set()
+  }
+
+  const warned = globalThis[WARNED_FLAG]
+  if (!warned.has(key)) {
+    warned.add(key)
+    console.warn(message)
+  }
+}
+
+function throwBlockedFirebaseCall(service, apiName, helpText) {
+  if (shouldAllowFirebaseCall()) return
+
+  const message = [
+    `[Storybook Firebase Guard] Blocked ${service} call: ${apiName}`,
+    "Real Firebase calls are disabled by default in Storybook.",
+    "Mock the component data/hooks used by this story instead.",
+    helpText,
+    "To opt out temporarily for a specific story, set: parameters.firebaseGuard.allow = true",
+    "To opt out globally, start Storybook with STORYBOOK_ALLOW_FIREBASE_CALLS=1"
+  ].join("\n")
+
+  warnOnce(`${service}:${apiName}`, message)
+  throw new Error(message)
+}
+
+function getStorybookAuthState() {
+  if (typeof globalThis === "undefined") return { user: null }
+
+  return globalThis[AUTH_STATE_KEY] ?? { user: null }
+}
+
+function setStorybookAuthState(state) {
+  if (typeof globalThis !== "undefined") {
+    globalThis[AUTH_STATE_KEY] = state
+  }
+  return state
+}
+
+module.exports = {
+  getStorybookAuthState,
+  setStorybookAuthState,
+  shouldAllowFirebaseCall,
+  throwBlockedFirebaseCall
+}

--- a/.storybook/firebase-guards/firestore.guard.js
+++ b/.storybook/firebase-guards/firestore.guard.js
@@ -1,0 +1,25 @@
+const firestore = require("@firebase/firestore")
+const { throwBlockedFirebaseCall } = require("./common")
+
+function block(apiName) {
+  return () => {
+    throwBlockedFirebaseCall(
+      "firestore",
+      apiName,
+      "Provide mocked query results or inject mock props into the component under test."
+    )
+  }
+}
+
+module.exports = {
+  ...firestore,
+  getDoc: block("getDoc"),
+  getDocs: block("getDocs"),
+  onSnapshot: block("onSnapshot"),
+  addDoc: block("addDoc"),
+  setDoc: block("setDoc"),
+  updateDoc: block("updateDoc"),
+  deleteDoc: block("deleteDoc"),
+  runTransaction: block("runTransaction"),
+  getCountFromServer: block("getCountFromServer")
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,8 @@
 /**
  * @type {import('@storybook/react/types').StorybookConfig}
  */
+const path = require("path")
+
 module.exports = {
   stories: [
     "../stories/**/*.stories.mdx",
@@ -24,6 +26,17 @@ module.exports = {
       use: ["file-loader"]
     })
     config.resolve.fallback = { fs: false, path: false }
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "firebase/firestore$": path.resolve(
+        __dirname,
+        "./firebase-guards/firestore.guard.js"
+      ),
+      "firebase/auth$": path.resolve(
+        __dirname,
+        "./firebase-guards/auth.guard.js"
+      )
+    }
     return config
   },
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,6 +9,9 @@ import React, { Suspense } from "react"
 import { I18nextProvider } from "react-i18next"
 // import i18n from "i18next"
 import i18n from "./i18n"
+const { mockLoggedOutAuthState } = require("./firebase-guards/auth.guard.js")
+
+mockLoggedOutAuthState()
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -60,6 +63,12 @@ export const parameters = {
 
 export const decorators = [
   (Story, context) => {
+    if (typeof window !== "undefined") {
+      window.__MAPLE_STORYBOOK_ALLOW_FIREBASE__ = Boolean(
+        context?.parameters?.firebaseGuard?.allow
+      )
+    }
+
     return (
       <Suspense fallback="Loading...">
         <I18nextProvider i18n={i18n}>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ git pull upstream main
 - `yarn dev:down`: Stop the application.
 - `yarn dev:update`: Update the application images. Run this whenever dependencies in `package.json` change.
 
+### Storybook Firebase Guard
+
+Storybook blocks real Firebase Auth and Firestore calls by default to prevent accidental network access from stories.
+
+If a story triggers a blocked call, Storybook throws an error with guidance about what to mock.
+
+Use these patterns when building stories:
+
+- Prefer passing mock props/data to components instead of rendering hook-driven containers.
+- If a component supports injection (for example, mock `profile`/`index` props), use that in the story args.
+- For auth-driven stories, use the helpers in [stories/utils/storybookFirebaseAuth.ts](stories/utils/storybookFirebaseAuth.ts) to switch between logged-out and logged-in user mocks.
+
+Opt-out options:
+
+- Per story: set `parameters.firebaseGuard.allow = true`.
+- Globally: run Storybook with `STORYBOOK_ALLOW_FIREBASE_CALLS=1`.
+
 Install the [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) and [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) browser extensions if you're developing frontend
 
 ## Contributing Backend Features to Dev/Prod:

--- a/components/EditProfilePage/PersonalInfoTab.tsx
+++ b/components/EditProfilePage/PersonalInfoTab.tsx
@@ -4,7 +4,7 @@ import { Form, Row, Col, Button } from "../bootstrap"
 import { Profile, ProfileHook } from "../db"
 import Input from "../forms/Input"
 import { TitledSectionCard } from "../shared"
-import { YourLegislators } from "./YourLegislators"
+import { YourLegislators, YourLegislatorsProps } from "./YourLegislators"
 import { OrgCategory, OrgCategories } from "components/auth"
 import { TooltipButton } from "components/buttons"
 import { useTranslation } from "next-i18next"
@@ -34,6 +34,7 @@ type Props = {
   setFormUpdated?: any
   className?: string
   isOrg?: boolean
+  legislatorsProps?: YourLegislatorsProps
 }
 
 async function updateProfile(
@@ -68,7 +69,8 @@ export function PersonalInfoTab({
   uid,
   className,
   setFormUpdated,
-  isOrg
+  isOrg,
+  legislatorsProps
 }: Props) {
   const {
     register,
@@ -271,7 +273,7 @@ export function PersonalInfoTab({
       {!isOrg && (
         <TitledSectionCard>
           <h2>{t("legislator.yourLegislators")}</h2>
-          <YourLegislators />
+          <YourLegislators {...legislatorsProps} />
         </TitledSectionCard>
       )}
 

--- a/components/EditProfilePage/YourLegislators.tsx
+++ b/components/EditProfilePage/YourLegislators.tsx
@@ -1,15 +1,21 @@
 import { Col, Row } from "../bootstrap"
+import { MemberSearchIndex, ProfileHook } from "../db"
 import { External } from "../links"
 import { SelectLegislators } from "../ProfilePage/SelectLegislators"
 import { useTranslation } from "next-i18next"
 
-export const YourLegislators = () => {
+export type YourLegislatorsProps = {
+  index?: MemberSearchIndex
+  profile?: ProfileHook
+}
+
+export const YourLegislators = ({ index, profile }: YourLegislatorsProps) => {
   const { t } = useTranslation("editProfile")
   return (
     <>
       <Row className="mt-3 mb-3 gap-3">
         <Col xs={12} md={6} className="your-legislators-width">
-          <SelectLegislators />
+          <SelectLegislators index={index} profile={profile} />
         </Col>
         <Col className="bg-secondary text-white rounded d-flex justify-content-center align-items-center pt-4 your-legislators-width">
           <p className="flex-grow-1">

--- a/components/ProfilePage/SelectLegislators.tsx
+++ b/components/ProfilePage/SelectLegislators.tsx
@@ -8,9 +8,12 @@ import {
 import { Loading, Search } from "../legislatorSearch"
 import { useTranslation } from "next-i18next"
 
-export const SelectLegislators: React.FC<
-  React.PropsWithChildren<unknown>
-> = () => {
+type SelectLegislatorsProps = {
+  index?: MemberSearchIndex
+  profile?: ProfileHook
+}
+
+const SelectLegislatorsWithHooks = () => {
   const { index, loading: searchLoading } = useMemberSearch(),
     profile = useProfile(),
     loading = profile.loading || searchLoading
@@ -20,6 +23,16 @@ export const SelectLegislators: React.FC<
   ) : (
     <LegislatorForm profile={profile} index={index!} />
   )
+}
+
+export const SelectLegislators: React.FC<
+  React.PropsWithChildren<SelectLegislatorsProps>
+> = ({ index, profile }) => {
+  if (index && profile) {
+    return <LegislatorForm profile={profile} index={index} />
+  }
+
+  return <SelectLegislatorsWithHooks />
 }
 
 export const LegislatorForm: React.FC<

--- a/stories/organisms/editprofile/personalInfoTal.stories.tsx
+++ b/stories/organisms/editprofile/personalInfoTal.stories.tsx
@@ -1,9 +1,52 @@
 import { Meta, StoryObj } from "@storybook/react"
 import { PersonalInfoTab } from "components/EditProfilePage/PersonalInfoTab"
-import { ProfileHook } from "components/db"
+import { MemberSearchIndex, ProfileHook } from "components/db"
 import { Providers } from "components/providers"
 import { wrapper } from "components/store"
 import { Provider as Redux } from "react-redux"
+
+const mockIndex: MemberSearchIndex = {
+  representatives: [
+    {
+      MemberCode: "H-001",
+      Name: "Rep. Ada Lovelace",
+      District: "1st Middlesex",
+      EmailAddress: "ada.lovelace@malegislature.gov",
+      Party: "D",
+      Branch: "House"
+    }
+  ],
+  senators: [
+    {
+      MemberCode: "S-001",
+      Name: "Sen. Grace Hopper",
+      District: "Middlesex & Suffolk",
+      EmailAddress: "grace.hopper@malegislature.gov",
+      Party: "D",
+      Branch: "Senate"
+    }
+  ]
+}
+
+const mockProfile = {
+  loading: false,
+  updatingRep: false,
+  updatingSenator: false,
+  profile: {
+    representative: {
+      id: "H-001",
+      name: "Rep. Ada Lovelace",
+      district: "1st Middlesex"
+    },
+    senator: {
+      id: "S-001",
+      name: "Sen. Grace Hopper",
+      district: "Middlesex & Suffolk"
+    }
+  },
+  updateRep: () => undefined,
+  updateSenator: () => undefined
+} as unknown as ProfileHook
 
 const meta: Meta = {
   title: "Organisms/Edit Profile/Personal Info Tab",
@@ -55,7 +98,11 @@ export const Primary: Story = {
     uid: "123",
     className: "",
     setFormUpdated: () => console.log("setFormUpdated"),
-    isOrg: false
+    isOrg: false,
+    legislatorsProps: {
+      index: mockIndex,
+      profile: mockProfile
+    }
   },
   name: "Personal Info Tab"
 }

--- a/stories/utils/storybookFirebaseAuth.ts
+++ b/stories/utils/storybookFirebaseAuth.ts
@@ -1,0 +1,85 @@
+import type { User } from "firebase/auth"
+
+type StorybookAuthState =
+  | {
+      user: null
+      claims?: undefined
+    }
+  | {
+      user: User
+      claims?: {
+        role?: string
+        email_verified?: boolean
+      }
+    }
+
+const AUTH_STATE_KEY = "__MAPLE_STORYBOOK_FIREBASE_AUTH_STATE__"
+
+function setGlobalAuthState(state: StorybookAuthState) {
+  if (typeof globalThis !== "undefined") {
+    ;(globalThis as any)[AUTH_STATE_KEY] = state
+  }
+}
+
+export function mockLoggedOutAuthState() {
+  const state: StorybookAuthState = { user: null }
+  setGlobalAuthState(state)
+  return state
+}
+
+export function mockLoggedInUserAuthState(overrides?: Partial<User>) {
+  const user = {
+    uid: "storybook-user",
+    email: "storybook-user@example.com",
+    emailVerified: true,
+    displayName: "Storybook User",
+    isAnonymous: false,
+    providerId: "firebase",
+    photoURL: null,
+    phoneNumber: null,
+    tenantId: null,
+    metadata: {
+      creationTime: "",
+      lastSignInTime: ""
+    },
+    providerData: [],
+    refreshToken: "storybook-refresh-token",
+    stsTokenManager: {
+      accessToken: "storybook-access-token",
+      refreshToken: "storybook-refresh-token",
+      expirationTime: Date.now() + 60 * 60 * 1000
+    },
+    getIdToken: async () => "storybook-id-token",
+    getIdTokenResult: async () => ({
+      token: "storybook-id-token",
+      authTime: "",
+      issuedAtTime: "",
+      expirationTime: "",
+      signInProvider: null,
+      claims: {
+        role: "user",
+        email_verified: true
+      }
+    }),
+    reload: async () => undefined,
+    delete: async () => undefined,
+    toJSON: () => ({})
+  } as unknown as User
+
+  const state: StorybookAuthState = {
+    user: { ...user, ...overrides },
+    claims: { role: "user", email_verified: true }
+  }
+
+  setGlobalAuthState(state)
+  return state
+}
+
+export function setStorybookAuthState(state: StorybookAuthState) {
+  setGlobalAuthState(state)
+  return state
+}
+
+export function resetStorybookAuthState() {
+  return mockLoggedOutAuthState()
+}


### PR DESCRIPTION
# Summary

I've noticed that some of our new Storybook stories are making actual Firebase API calls (for Firestore and Auth) - but Storybook is basically a UI Design Library for us, so this is undesirable.

This PR adds default overrides for Firestore and Firebase Auth calls to our Storybook config to block real API calls from the Storybook app. If you attempt to make a Firebase call erroneously, it will fail (and warn about the failing call in the console). This includes a new short section in the README to call this new behavior out.

This PR addresses *one* of the instances this occurs with the "Select Your Legislators" section of the Edit Profile page as a test - I plan to circle back and address the new Ballot Initiative-related stories after we've got final approval on the redesigns attached to them on the dev site.