### PR TITLE
Remove showLLMFeatures feature flag

### DIFF
--- a/components/bill/Summary.tsx
+++ b/components/bill/Summary.tsx
@@ -5,7 +5,6 @@ import type { ModalProps } from "react-bootstrap"
 import styled, { ThemeConsumer } from "styled-components"
 import { useMediaQuery } from "usehooks-ts"
 import { Button, Col, Container, Image, Modal, Row, Stack } from "../bootstrap"
-import { useFlags } from "../featureFlags"
 import { firestore } from "../firebase"
 import * as links from "../links"
 import {
@@ -121,8 +120,6 @@ export const Summary = ({
   const isBallotMeasure =
     bill?.currentCommittee?.id === currentBallotInitiativeCommittee
 
-  const { showLLMFeatures } = useFlags()
-
   const { t } = useTranslation("common")
   const isMobile = useMediaQuery("(max-width: 991px)")
 
@@ -210,65 +207,59 @@ export const Summary = ({
           <></>
         )}
       </Row>
-      {showLLMFeatures ? (
+      {bill.summary !== undefined && bill.topics !== undefined ? (
         <>
-          {bill.summary !== undefined && bill.topics !== undefined ? (
-            <>
-              <hr className={`m-0 border-bottom border-2`} />
-              <SmartDisclaimer />
-            </>
-          ) : bill.summary !== undefined && isBallotMeasure ? (
-            <>
-              <hr className={`m-0 mb-3 border-bottom border-2`} />
-            </>
-          ) : (
-            <></>
-          )}
-          {bill.summary !== undefined && isBallotMeasure ? (
-            <BallotSummaryRow className={`mx-1 mb-3`}>
-              {bill.summary.length > BALLOT_SUMMARY_CHAR_LIMIT ? (
-                <>
-                  {bill.summary.slice(0, BALLOT_SUMMARY_CHAR_LIMIT)}…{" "}
-                  <StyledButton
-                    variant="link"
-                    onClick={() => setShowFullSummary(true)}
-                  >
-                    {t("bill.view_full_summary")}
-                  </StyledButton>
-                  <Modal
-                    show={showFullSummary}
-                    onHide={() => setShowFullSummary(false)}
-                    size="lg"
-                  >
-                    <Modal.Header
-                      closeButton
-                      onClick={() => setShowFullSummary(false)}
-                    >
-                      <Modal.Title>{bill?.id}</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body className="bg-white">
-                      <FormattedBillDetails>
-                        {bill.summary}
-                      </FormattedBillDetails>
-                    </Modal.Body>
-                  </Modal>
-                </>
-              ) : (
-                bill.summary
-              )}
-            </BallotSummaryRow>
-          ) : (
-            <Row className="mx-1 mb-3">{bill.summary}</Row>
-          )}
-          <Row className={`d-flex mx-0 my-1`} xs="auto">
-            {bill.topics?.map(t => (
-              <SmartTag key={t.topic} topic={t} />
-            ))}
-          </Row>
+          <hr className={`m-0 border-bottom border-2`} />
+          <SmartDisclaimer />
+        </>
+      ) : bill.summary !== undefined && isBallotMeasure ? (
+        <>
+          <hr className={`m-0 mb-3 border-bottom border-2`} />
         </>
       ) : (
         <></>
       )}
+      {bill.summary !== undefined && isBallotMeasure ? (
+        <BallotSummaryRow className={`mx-1 mb-3`}>
+          {bill.summary.length > BALLOT_SUMMARY_CHAR_LIMIT ? (
+            <>
+              {bill.summary.slice(0, BALLOT_SUMMARY_CHAR_LIMIT)}…{" "}
+              <StyledButton
+                variant="link"
+                onClick={() => setShowFullSummary(true)}
+              >
+                {t("bill.view_full_summary")}
+              </StyledButton>
+              <Modal
+                show={showFullSummary}
+                onHide={() => setShowFullSummary(false)}
+                size="lg"
+              >
+                <Modal.Header
+                  closeButton
+                  onClick={() => setShowFullSummary(false)}
+                >
+                  <Modal.Title>{bill?.id}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body className="bg-white">
+                  <FormattedBillDetails>
+                    {bill.summary}
+                  </FormattedBillDetails>
+                </Modal.Body>
+              </Modal>
+            </>
+          ) : (
+            bill.summary
+          )}
+        </BallotSummaryRow>
+      ) : (
+        <Row className="mx-1 mb-3">{bill.summary}</Row>
+      )}
+      <Row className={`d-flex mx-0 my-1`} xs="auto">
+        {bill.topics?.map(t => (
+          <SmartTag key={t.topic} topic={t} />
+        ))}
+      </Row>
     </SummaryContainer>
   )
 }

--- a/components/bill/Summary.tsx
+++ b/components/bill/Summary.tsx
@@ -242,9 +242,7 @@ export const Summary = ({
                   <Modal.Title>{bill?.id}</Modal.Title>
                 </Modal.Header>
                 <Modal.Body className="bg-white">
-                  <FormattedBillDetails>
-                    {bill.summary}
-                  </FormattedBillDetails>
+                  <FormattedBillDetails>{bill.summary}</FormattedBillDetails>
                 </Modal.Body>
               </Modal>
             </>

--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -12,8 +12,6 @@ export const FeatureFlags = z.object({
   followOrg: z.boolean().default(false),
   /** Lobbying Table */
   lobbyingTable: z.boolean().default(false),
-  /** LLM Bill Summary and Tags **/
-  showLLMFeatures: z.boolean().default(false),
   /** Hearings and Transcriptions **/
   hearingsAndTranscriptions: z.boolean().default(false),
   /** Phone Verification UI changes **/
@@ -40,7 +38,6 @@ const defaults: Record<Env, FeatureFlags> = {
     billTracker: true,
     followOrg: true,
     lobbyingTable: false,
-    showLLMFeatures: true,
     hearingsAndTranscriptions: true,
     phoneVerificationUI: true,
     ballotQuestions: true,
@@ -52,7 +49,6 @@ const defaults: Record<Env, FeatureFlags> = {
     billTracker: false,
     followOrg: true,
     lobbyingTable: false,
-    showLLMFeatures: true,
     hearingsAndTranscriptions: true,
     phoneVerificationUI: false,
     ballotQuestions: false,
@@ -64,7 +60,6 @@ const defaults: Record<Env, FeatureFlags> = {
     billTracker: false,
     followOrg: true,
     lobbyingTable: false,
-    showLLMFeatures: true,
     hearingsAndTranscriptions: true,
     phoneVerificationUI: true,
     ballotQuestions: false,


### PR DESCRIPTION
Per #2079. The LLM bill summaries and tags have been on in all three environments (development, production, test) for a while, so the `showLLMFeatures` gate isn't doing anything anymore.

- Drop `showLLMFeatures` from the `FeatureFlags` schema and from the three env defaults
- Inline the LLM summary / tags block in `Summary.tsx` (no behavior change since the flag was on everywhere)
- Drop the now-unused `useFlags` import from `Summary.tsx`

I couldn't easily run `yarn check-types` locally (yarn isn't on this machine) but the change is purely removing a flag whose only call site was the conditional I deleted, plus the import for `useFlags` that was only used by that call site. Happy to add anything if CI catches something.

Closes #2079.