### PR TITLE
revert multi-column layout for browse pages

### DIFF
--- a/components/search/SearchContainer.tsx
+++ b/components/search/SearchContainer.tsx
@@ -116,15 +116,6 @@ export const SearchContainer = styled.div`
     display: none;
   }
 
-  .ais-Hits-list {
-    columns: 2;
-    column-gap: 1.15rem;
-
-    @media (max-width: 768px) {
-      columns: 1;
-    }
-  }
-
   .ais-Hits-item {
     background: none;
     break-inside: avoid;


### PR DESCRIPTION
# Summary

As part of the recent redesign of the browse pages, we introduced a two-column layout for the search results in larger screen widths. That works for Ballot Initiatives (where there are only ~10 items at any given time), but is a bit awkward for our other Browse Pages (bills, hearings, and testimony).
This PR ensures that the Browse Bills, Browse Hearings, and Browse Testimony search results display in a single column.
Full description in Issue #2147

# Checklist

- [N/A] On the frontend, I've made my strings translate-able.
- [N/A] If I've added shared components, I've added a storybook story.
- [Y] I've made pages responsive and look good on mobile.
- [N/A] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Steps to test/reproduce

1. Go to Browse Bills page. Confirm that search results render in one column.
2. Go to Browse Testimony page. Confirm that search results render in one column.
3. Go to Browse Hearings page. Confirm that search results render in one column.
4.  Go to Browse Ballot Initiatives page. Confirm that search results render in TWO columns.