### PR TITLE
homepage update

### DIFF
--- a/components/TestimonyCallout/TestimonyCalloutSection.tsx
+++ b/components/TestimonyCallout/TestimonyCalloutSection.tsx
@@ -6,6 +6,8 @@ import TestimonyCallout from "./TestimonyCallout"
 import { useTranslation } from "next-i18next"
 import { Internal } from "components/links"
 
+import styles from "components/homepage/Homepage.module.css"
+
 export default function TestimonyCalloutSection() {
   const recentTestimony = useRecentTestimony(4)
   const isMobile = useMediaQuery("(max-width: 768px)")
@@ -13,10 +15,10 @@ export default function TestimonyCalloutSection() {
   const { t } = useTranslation("testimony")
 
   return (
-    <Container fluid>
-      <Row className="mt-5 justify-content-center">
-        <Col xs={10} md={6}>
-          <h1>{t("testimonyCalloutSection.peopleSaying")}</h1>
+    <section className={styles.sectionShell}>
+      <Row className={styles.peopleSaying}>
+        <Col xs={10} md={6} className={styles.sectionTitle}>
+          <h2>{t("testimonyCalloutSection.peopleSaying")}</h2>
         </Col>
         <Col xs={10} md={3}>
           <div>
@@ -66,6 +68,6 @@ export default function TestimonyCalloutSection() {
           </Col>
         </Row>
       )}
-    </Container>
+    </section>
   )
 }

--- a/components/TestimonyCallout/TestimonyCalloutSection.tsx
+++ b/components/TestimonyCallout/TestimonyCalloutSection.tsx
@@ -5,7 +5,6 @@ import { useRecentTestimony } from "../db"
 import TestimonyCallout from "./TestimonyCallout"
 import { useTranslation } from "next-i18next"
 import { Internal } from "components/links"
-
 import styles from "components/homepage/Homepage.module.css"
 
 export default function TestimonyCalloutSection() {

--- a/components/homepage/HearingsSection.tsx
+++ b/components/homepage/HearingsSection.tsx
@@ -39,7 +39,7 @@ export function HearingsSectionContent({
           <h2 id="homepage-upcoming-hearings" className={styles.hearingsTitle}>
             {t("hearings.title")}
           </h2>
-          <Internal href="/bills" className={styles.hearingsActionDesktop}>
+          <Internal href="/hearings" className={styles.hearingsActionDesktop}>
             {t("hearings.action")}
           </Internal>
         </div>
@@ -78,7 +78,7 @@ export function HearingsSectionContent({
             {t("hearingsScheduled.noEvents")}
           </p>
         )}
-        <Internal href="/bills" className={styles.hearingsActionMobile}>
+        <Internal href="/hearings" className={styles.hearingsActionMobile}>
           {t("hearings.action")}
         </Internal>
       </div>

--- a/components/homepage/Homepage.module.css
+++ b/components/homepage/Homepage.module.css
@@ -10,6 +10,7 @@
 
 .hero,
 .didYouKnow,
+.peopleSaying,
 .features,
 .hearings {
   padding: 5rem 0;

--- a/public/locales/en/homepage.json
+++ b/public/locales/en/homepage.json
@@ -49,7 +49,7 @@
   },
   "hearings": {
     "title": "Upcoming Hearings",
-    "action": "Browse Policies",
+    "action": "Browse Hearings",
     "loading": "Loading upcoming hearings...",
     "topic": "Massachusetts Legislature",
     "appPreviewAlt": "MAPLE platform preview",


### PR DESCRIPTION
-Fix margins on Testimony Callout Section on Home Page
-Shrink the testimony callout boxes so they match the other homepage sections
-Fix “Browse Policies” copy text by the Upcoming Hearings section on the home page to read “Browse Hearings” (and link to the Browse Hearings page)