### PR TITLE
Legislator page (sidebar: biography)

### DIFF
--- a/components/EditProfilePage/PersonalInfoTab.tsx
+++ b/components/EditProfilePage/PersonalInfoTab.tsx
@@ -10,7 +10,7 @@ import { TooltipButton } from "components/buttons"
 import { useTranslation } from "next-i18next"
 import styled from "styled-components"
 
-type UpdateProfileData = {
+export type UpdateProfileData = {
   fullName: string
   aboutYou: string
   twitter: string
@@ -37,7 +37,7 @@ type Props = {
   legislatorsProps?: YourLegislatorsProps
 }
 
-async function updateProfile(
+export async function updateProfile(
   { profile, actions, uid }: Props,
   data: UpdateProfileData
 ) {

--- a/components/db/profile/urlCleanup.ts
+++ b/components/db/profile/urlCleanup.ts
@@ -7,7 +7,7 @@ export function cleanSocialLinks(network: keyof SocialLinks, link: string) {
       const index: number = path.indexOf(".com/") + 5
       path = path.substring(index)
     }
-    if (network === "mastodon" && path.startsWith("@")) {
+    if (path && network === "mastodon" && path.startsWith("@")) {
       path = path.substring(1)
     }
   }

--- a/components/legislator/LegislatorPage.tsx
+++ b/components/legislator/LegislatorPage.tsx
@@ -120,7 +120,7 @@ export function LegislatorPage(props: { id: string }) {
           <LegislatorTabs />
         </Col>
         <Col className={`mt-4`} md="3">
-          <LegislatorSidebar pageId={props.id} />
+          <LegislatorSidebar pageId={props.id} publicProfile={profile} />
         </Col>
       </Row>
     </Container>

--- a/components/legislator/LegislatorPage.tsx
+++ b/components/legislator/LegislatorPage.tsx
@@ -120,7 +120,7 @@ export function LegislatorPage(props: { id: string }) {
           <LegislatorTabs />
         </Col>
         <Col className={`mt-4`} md="3">
-          <LegislatorSidebar />
+          <LegislatorSidebar pageId={props.id} />
         </Col>
       </Row>
     </Container>

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -1,3 +1,131 @@
-export function Biography() {
-  return <div>- Biography</div>
+import { useTranslation } from "next-i18next"
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import styled from "styled-components"
+
+import { Form, Row, Spinner } from "../../bootstrap"
+import { Profile, useProfile } from "../../db"
+import Input from "../../forms/Input"
+
+import { useAuth } from "components/auth"
+
+type UpdateProfileData = {
+  legislatorBio: string
+}
+
+export function Biography({ pageId }: { pageId: string }) {
+  const { user } = useAuth()
+  const uid = user?.uid
+  // `useProfile` needs to be replaced with a function that uses the pageId
+  // instead of the current user's id
+  const result = useProfile()
+
+  let pageOwner = false
+
+  if (uid === pageId) {
+    pageOwner = true
+  }
+
+  if (result.loading) {
+    return (
+      <Row>
+        <Spinner animation="border" className="mx-auto" />
+      </Row>
+    )
+  }
+
+  if (result?.profile && pageOwner) {
+    // the user is the legislator whose page this is
+    // therefore they get edit privledges
+    return <SelfBiography pageId={pageId} profile={result.profile} />
+  }
+
+  // the user is not the legislator whose page this is
+  // therefore they get read-only privledges
+  return <LegislatorBiography />
+}
+
+function LegislatorBiography() {
+  return <div>Sample Biography</div>
+}
+
+const BioBlock = styled.div`
+  background-color: white;
+  border: "1px #ced4da solid";
+  border-radius: 5px;
+  margin-top: 8px;
+  padding: 8px 16px;
+`
+
+const BioButton = styled.button`
+  font-size: 11px;
+`
+
+const BioTitle = styled.div`
+  font-size: 11px;
+  font-weight: 700;
+  color: #0b0a3e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 10px;
+`
+
+function SelfBiography({
+  pageId,
+  profile
+}: {
+  pageId: string
+  profile: Profile
+}) {
+  const {
+    register,
+    formState: { errors, isDirty },
+    handleSubmit
+  } = useForm<UpdateProfileData>()
+
+  // `about` should be replaced with a property along the lines of legislatorBio
+  // or whatever is appropriate
+  const { about }: Profile = profile
+
+  const onSubmit = handleSubmit(async update => {
+    // await updateProfile({ actions }, update)
+    location.assign(`/legislators/profile?id=${pageId}`)
+    setFormUpdated(false)
+  })
+
+  const { t } = useTranslation("legislators")
+  const [formUpdated, setFormUpdated] = useState(false)
+
+  useEffect(() => {
+    setFormUpdated(isDirty)
+  }, [isDirty, setFormUpdated])
+
+  return (
+    <BioBlock>
+      <Form onSubmit={onSubmit}>
+        <div className={`d-flex justify-content-between`}>
+          <BioTitle className={`align-self-center d-inline my-1`}>
+            Biography
+          </BioTitle>
+          <BioButton
+            type="submit"
+            className={`btn btn-primary d-inline m-1 p-1 w-auto`}
+            disabled={!formUpdated}
+          >
+            Submit
+          </BioButton>
+        </div>
+        <Input
+          as="textarea"
+          {...register("legislatorBio")}
+          style={{ height: "10rem" }}
+          className="mt-3"
+          label={t("editBio")}
+          // `about` should be replaced with a property along the lines of legislatorBio
+          // or whatever is appropriate
+          defaultValue={about}
+        />
+      </Form>
+    </BioBlock>
+  )
 }

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -4,14 +4,14 @@ import { useForm } from "react-hook-form"
 import styled from "styled-components"
 
 import { Form, Row, Spinner } from "../../bootstrap"
-import { Profile, useProfile } from "../../db"
+import { Profile, ProfileHook, useProfile } from "../../db"
 import Input from "../../forms/Input"
 
 import { useAuth } from "components/auth"
-
-type UpdateProfileData = {
-  legislatorBio: string
-}
+import {
+  updateProfile,
+  UpdateProfileData
+} from "components/EditProfilePage/PersonalInfoTab"
 
 const BioBlock = styled.div`
   background-color: white;
@@ -34,12 +34,16 @@ const BioTitle = styled.div`
   margin-bottom: 10px;
 `
 
-export function Biography({ pageId }: { pageId: string }) {
+export function Biography({
+  pageId,
+  publicProfile
+}: {
+  pageId: string
+  publicProfile: Profile | undefined
+}) {
   const { user } = useAuth()
   const uid = user?.uid
-  // `useProfile` needs to be replaced with a function that uses
-  //  the pageId instead of the current user's id
-  const result = useProfile()
+  const pageOwnerResult = useProfile()
 
   let pageOwner = false
 
@@ -47,7 +51,7 @@ export function Biography({ pageId }: { pageId: string }) {
     pageOwner = true
   }
 
-  if (result.loading) {
+  if (pageOwnerResult.loading) {
     return (
       <Row>
         <Spinner animation="border" className="mx-auto" />
@@ -55,39 +59,43 @@ export function Biography({ pageId }: { pageId: string }) {
     )
   }
 
-  if (result?.profile && pageOwner) {
+  if (pageOwnerResult.profile && pageOwner) {
     // the user is the legislator whose page this is
     // therefore they get edit privledges
-    return <SelfBiography pageId={pageId} profile={result.profile} />
+    return (
+      <SelfBiography
+        actions={pageOwnerResult}
+        pageId={pageId}
+        profile={pageOwnerResult.profile}
+      />
+    )
   }
 
-  if (result?.profile) {
+  if (publicProfile) {
     // the user is not the legislator whose page this is
     // therefore they get read-only privledges
-    return <LegislatorBiography profile={result.profile} />
+    return <LegislatorBiography profile={publicProfile} />
   }
 }
 
 function LegislatorBiography({ profile }: { profile: Profile }) {
-  // `about` should be replaced with a property such as
-  // legislatorBio or whatever is appropriate
   const { about }: Profile = profile
   const { t } = useTranslation("legislators")
 
   return (
     <BioBlock>
       <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
-      {/* `about` should be replaced with a property such as *
-       * legislatorBio or whatever is appropriate            */}
       <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
     </BioBlock>
   )
 }
 
 function SelfBiography({
+  actions,
   pageId,
   profile
 }: {
+  actions: ProfileHook
   pageId: string
   profile: Profile
 }) {
@@ -97,12 +105,10 @@ function SelfBiography({
     handleSubmit
   } = useForm<UpdateProfileData>()
 
-  // `about` should be replaced with a property such as
-  // legislatorBio or whatever is appropriate
   const { about }: Profile = profile
 
   const onSubmit = handleSubmit(async update => {
-    // await updateProfile({ actions }, update)
+    await updateProfile({ profile, actions }, update)
     location.assign(`/legislators/profile?id=${pageId}`)
     setFormUpdated(false)
   })
@@ -131,12 +137,10 @@ function SelfBiography({
         </div>
         <Input
           as="textarea"
-          {...register("legislatorBio")}
+          {...register("aboutYou")}
           style={{ height: "10rem" }}
           className="mt-3"
           label={t("editBio")}
-          // `about` should be replaced with a property such as
-          // legislatorBio or whatever is appropriate
           defaultValue={about}
         />
       </Form>

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -13,11 +13,33 @@ type UpdateProfileData = {
   legislatorBio: string
 }
 
+const BioBlock = styled.div`
+  background-color: white;
+  border: "1px #ced4da solid";
+  border-radius: 5px;
+  margin-top: 8px;
+  padding: 8px 16px;
+`
+
+const BioButton = styled.button`
+  font-size: 11px;
+`
+
+const BioTitle = styled.div`
+  font-size: 11px;
+  font-weight: 700;
+  color: #0b0a3e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 10px;
+`
+
 export function Biography({ pageId }: { pageId: string }) {
   const { user } = useAuth()
   const uid = user?.uid
-  // `useProfile` needs to be replaced with a function that uses the pageId
-  // instead of the current user's id
+  // `useProfile` ought to be replaced with a function that uses the pageId
+  // instead of the current user's id but not strictly neccessary
+  // since the display conditions should only occur when (pageOwner = true)
   const result = useProfile()
 
   let pageOwner = false
@@ -40,35 +62,28 @@ export function Biography({ pageId }: { pageId: string }) {
     return <SelfBiography pageId={pageId} profile={result.profile} />
   }
 
-  // the user is not the legislator whose page this is
-  // therefore they get read-only privledges
-  return <LegislatorBiography />
+  if (result?.profile) {
+    // the user is not the legislator whose page this is
+    // therefore they get read-only privledges
+    return <LegislatorBiography profile={result.profile} />
+  }
 }
 
-function LegislatorBiography() {
-  return <div>Sample Biography</div>
+function LegislatorBiography({ profile }: { profile: Profile }) {
+  // `about` should be replaced with a property along the lines of legislatorBio
+  // or whatever is appropriate
+  const { about }: Profile = profile
+  const { t } = useTranslation("legislators")
+
+  return (
+    <BioBlock>
+      <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
+      {/* `about` should be replaced with a property along the lines of *
+       * legislatorBio // or whatever is appropriate                   */}
+      <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
+    </BioBlock>
+  )
 }
-
-const BioBlock = styled.div`
-  background-color: white;
-  border: "1px #ced4da solid";
-  border-radius: 5px;
-  margin-top: 8px;
-  padding: 8px 16px;
-`
-
-const BioButton = styled.button`
-  font-size: 11px;
-`
-
-const BioTitle = styled.div`
-  font-size: 11px;
-  font-weight: 700;
-  color: #0b0a3e;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 10px;
-`
 
 function SelfBiography({
   pageId,
@@ -105,14 +120,14 @@ function SelfBiography({
       <Form onSubmit={onSubmit}>
         <div className={`d-flex justify-content-between`}>
           <BioTitle className={`align-self-center d-inline my-1`}>
-            Biography
+            {t("biography")}
           </BioTitle>
           <BioButton
             type="submit"
             className={`btn btn-primary d-inline m-1 p-1 w-auto`}
             disabled={!formUpdated}
           >
-            Submit
+            {t("submit")}
           </BioButton>
         </div>
         <Input

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -85,7 +85,11 @@ function LegislatorBiography({ profile }: { profile: Profile }) {
   return (
     <BioBlock>
       <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
-      <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
+      {!about ? (
+        <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
+      ) : (
+        <div style={{ whiteSpace: "pre-wrap" }}>{t("notClaimed")}</div>
+      )}
     </BioBlock>
   )
 }

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -130,7 +130,7 @@ function EditableBiography({
           style={{ fontSize: "11px", height: "10rem" }}
           className="mt-3"
           label={t("editBio")}
-          defaultValue={about}
+          defaultValue={about ? about : t("addBio")}
         />
       </Form>
     </BioBlock>
@@ -144,11 +144,9 @@ function ReadonlyBiography({ profile }: { profile: Profile }) {
   return (
     <BioBlock>
       <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
-      {about ? (
-        <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
-      ) : (
-        <div style={{ whiteSpace: "pre-wrap" }}>{t("notClaimed")}</div>
-      )}
+      <div style={{ whiteSpace: "pre-wrap" }}>
+        {about ? about : t("notClaimed")}
+      </div>
     </BioBlock>
   )
 }

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -64,7 +64,7 @@ export function Biography({
     // the user is the legislator whose page this is
     // therefore they get edit privledges
     return (
-      <SelfBiography
+      <EditableBiography
         actions={pageOwnerResult}
         pageId={pageId}
         profile={pageOwnerResult.profile}
@@ -75,11 +75,11 @@ export function Biography({
   if (publicProfile) {
     // the user is not the legislator whose page this is
     // therefore they get read-only privledges
-    return <LegislatorBiography profile={publicProfile} />
+    return <ReadonlyBiography profile={publicProfile} />
   }
 }
 
-function LegislatorBiography({ profile }: { profile: Profile }) {
+function ReadonlyBiography({ profile }: { profile: Profile }) {
   const { about }: Profile = profile
   const { t } = useTranslation("legislators")
 
@@ -95,7 +95,7 @@ function LegislatorBiography({ profile }: { profile: Profile }) {
   )
 }
 
-function SelfBiography({
+function EditableBiography({
   actions,
   pageId,
   profile

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -37,9 +37,8 @@ const BioTitle = styled.div`
 export function Biography({ pageId }: { pageId: string }) {
   const { user } = useAuth()
   const uid = user?.uid
-  // `useProfile` ought to be replaced with a function that uses the pageId
-  // instead of the current user's id but not strictly neccessary
-  // since the display conditions should only occur when (pageOwner = true)
+  // `useProfile` needs to be replaced with a function that uses
+  //  the pageId instead of the current user's id
   const result = useProfile()
 
   let pageOwner = false
@@ -70,16 +69,16 @@ export function Biography({ pageId }: { pageId: string }) {
 }
 
 function LegislatorBiography({ profile }: { profile: Profile }) {
-  // `about` should be replaced with a property along the lines of legislatorBio
-  // or whatever is appropriate
+  // `about` should be replaced with a property such as
+  // legislatorBio or whatever is appropriate
   const { about }: Profile = profile
   const { t } = useTranslation("legislators")
 
   return (
     <BioBlock>
       <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
-      {/* `about` should be replaced with a property along the lines of *
-       * legislatorBio // or whatever is appropriate                   */}
+      {/* `about` should be replaced with a property such as *
+       * legislatorBio or whatever is appropriate            */}
       <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
     </BioBlock>
   )
@@ -98,8 +97,8 @@ function SelfBiography({
     handleSubmit
   } = useForm<UpdateProfileData>()
 
-  // `about` should be replaced with a property along the lines of legislatorBio
-  // or whatever is appropriate
+  // `about` should be replaced with a property such as
+  // legislatorBio or whatever is appropriate
   const { about }: Profile = profile
 
   const onSubmit = handleSubmit(async update => {
@@ -136,8 +135,8 @@ function SelfBiography({
           style={{ height: "10rem" }}
           className="mt-3"
           label={t("editBio")}
-          // `about` should be replaced with a property along the lines of legislatorBio
-          // or whatever is appropriate
+          // `about` should be replaced with a property such as
+          // legislatorBio or whatever is appropriate
           defaultValue={about}
         />
       </Form>

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -17,16 +17,17 @@ const BioBlock = styled.div`
   background-color: white;
   border: "1px #ced4da solid";
   border-radius: 5px;
+  font-size: 11px;
   margin-top: 8px;
   padding: 8px 16px;
 `
 
 const BioButton = styled.button`
-  font-size: 11px;
+  font-size: 9px;
+  padding: 2px;
 `
 
 const BioTitle = styled.div`
-  font-size: 11px;
   font-weight: 700;
   color: #0b0a3e;
   text-transform: uppercase;
@@ -85,7 +86,7 @@ function LegislatorBiography({ profile }: { profile: Profile }) {
   return (
     <BioBlock>
       <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
-      {!about ? (
+      {about ? (
         <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
       ) : (
         <div style={{ whiteSpace: "pre-wrap" }}>{t("notClaimed")}</div>
@@ -133,7 +134,7 @@ function SelfBiography({
           </BioTitle>
           <BioButton
             type="submit"
-            className={`btn btn-primary d-inline m-1 p-1 w-auto`}
+            className={`btn btn-primary d-inline m-1 w-auto`}
             disabled={!formUpdated}
           >
             {t("submit")}
@@ -142,7 +143,7 @@ function SelfBiography({
         <Input
           as="textarea"
           {...register("aboutYou")}
-          style={{ height: "10rem" }}
+          style={{ fontSize: "11px", height: "10rem" }}
           className="mt-3"
           label={t("editBio")}
           defaultValue={about}

--- a/components/legislator/SidebarComponents/Biography.tsx
+++ b/components/legislator/SidebarComponents/Biography.tsx
@@ -79,22 +79,6 @@ export function Biography({
   }
 }
 
-function ReadonlyBiography({ profile }: { profile: Profile }) {
-  const { about }: Profile = profile
-  const { t } = useTranslation("legislators")
-
-  return (
-    <BioBlock>
-      <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
-      {about ? (
-        <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
-      ) : (
-        <div style={{ whiteSpace: "pre-wrap" }}>{t("notClaimed")}</div>
-      )}
-    </BioBlock>
-  )
-}
-
 function EditableBiography({
   actions,
   pageId,
@@ -149,6 +133,22 @@ function EditableBiography({
           defaultValue={about}
         />
       </Form>
+    </BioBlock>
+  )
+}
+
+function ReadonlyBiography({ profile }: { profile: Profile }) {
+  const { about }: Profile = profile
+  const { t } = useTranslation("legislators")
+
+  return (
+    <BioBlock>
+      <BioTitle className={`my-1`}>{t("biography")}</BioTitle>
+      {about ? (
+        <div style={{ whiteSpace: "pre-wrap" }}>{about}</div>
+      ) : (
+        <div style={{ whiteSpace: "pre-wrap" }}>{t("notClaimed")}</div>
+      )}
     </BioBlock>
   )
 }

--- a/components/legislator/SidebarComponents/LegislatorSidebar.tsx
+++ b/components/legislator/SidebarComponents/LegislatorSidebar.tsx
@@ -1,14 +1,21 @@
 import { Biography } from "./Biography"
 import { OtherTestimony } from "./OtherTestimony"
 import { UpcomingHearings } from "./UpcomingHearings"
+import { Profile } from "../../db"
 
-export function LegislatorSidebar({ pageId }: { pageId: string }) {
+export function LegislatorSidebar({
+  pageId,
+  publicProfile
+}: {
+  pageId: string
+  publicProfile: Profile | undefined
+}) {
   return (
     <>
       Sidebar Components
       <OtherTestimony />
       <UpcomingHearings />
-      <Biography pageId={pageId} />
+      <Biography pageId={pageId} publicProfile={publicProfile} />
     </>
   )
 }

--- a/components/legislator/SidebarComponents/LegislatorSidebar.tsx
+++ b/components/legislator/SidebarComponents/LegislatorSidebar.tsx
@@ -2,13 +2,13 @@ import { Biography } from "./Biography"
 import { OtherTestimony } from "./OtherTestimony"
 import { UpcomingHearings } from "./UpcomingHearings"
 
-export function LegislatorSidebar() {
+export function LegislatorSidebar({ pageId }: { pageId: string }) {
   return (
     <>
       Sidebar Components
       <OtherTestimony />
       <UpcomingHearings />
-      <Biography />
+      <Biography pageId={pageId} />
     </>
   )
 }

--- a/components/legislator/SidebarComponents/LegislatorSidebar.tsx
+++ b/components/legislator/SidebarComponents/LegislatorSidebar.tsx
@@ -1,7 +1,7 @@
+import { Profile } from "../../db"
 import { Biography } from "./Biography"
 import { OtherTestimony } from "./OtherTestimony"
 import { UpcomingHearings } from "./UpcomingHearings"
-import { Profile } from "../../db"
 
 export function LegislatorSidebar({
   pageId,

--- a/components/legislator/SidebarComponents/LegislatorSidebar.tsx
+++ b/components/legislator/SidebarComponents/LegislatorSidebar.tsx
@@ -12,7 +12,6 @@ export function LegislatorSidebar({
 }) {
   return (
     <>
-      Sidebar Components
       <OtherTestimony />
       <UpcomingHearings />
       <Biography pageId={pageId} publicProfile={publicProfile} />

--- a/public/locales/en/legislators.json
+++ b/public/locales/en/legislators.json
@@ -1,4 +1,5 @@
 {
+  "addBio": "Add your biography",
   "billsSponsored": "Bills Sponsored",
   "biography": "Biography",
   "cosponsored": "Cosponsored",

--- a/public/locales/en/legislators.json
+++ b/public/locales/en/legislators.json
@@ -6,6 +6,7 @@
   "fundsRaised": "Funds Raised",
   "home": "Home",
   "legislators": "Legislators",
+  "notClaimed": "This legislator has not claimed their MAPLE account",
   "submit": "Submit",
   "tabs": {
     "bills": "Bills",

--- a/public/locales/en/legislators.json
+++ b/public/locales/en/legislators.json
@@ -1,6 +1,7 @@
 {
   "billsSponsored": "Bills Sponsored",
   "cosponsored": "Cosponsored",
+  "editBio": "Edit your biography",
   "fundsRaised": "Funds Raised",
   "home": "Home",
   "legislators": "Legislators",

--- a/public/locales/en/legislators.json
+++ b/public/locales/en/legislators.json
@@ -1,10 +1,12 @@
 {
   "billsSponsored": "Bills Sponsored",
+  "biography": "Biography",
   "cosponsored": "Cosponsored",
   "editBio": "Edit your biography",
   "fundsRaised": "Funds Raised",
   "home": "Home",
   "legislators": "Legislators",
+  "submit": "Submit",
   "tabs": {
     "bills": "Bills",
     "district": "District",


### PR DESCRIPTION
# Summary

biography portion of #2136

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

Public Profile aboutYou/Bio of a given Legislator shown as read-only to most users:

<img width="1158" height="609" alt="image" src="https://github.com/user-attachments/assets/cc1ec437-c091-4f1d-adab-3092422132e5" />

read-only result when Legislator has not edited their aboutYou/Bio:

<img width="451" height="269" alt="image" src="https://github.com/user-attachments/assets/4a0815ed-9df3-43fc-b974-29d842ab91dd" />

Edit Form show to the pageOwner/Legislator in question:

<img width="290" height="386" alt="image" src="https://github.com/user-attachments/assets/3ee4c24f-cf9f-4d2e-ad38-796b255e45ee" />

# Known issues

none

# Steps to test/reproduce

1. Go to ./legislators/profile?id=XBPiuP0JN5ZwAMXb19j68GJduuO2
2. verify read-only public view of Biography section
3. replace the above id with your id and be logged in
4. verify biography section is now an editable form
