### PR TITLE
Better Logs for Hearing Scraper

### DIFF
--- a/functions/src/events/scrapeEvents.ts
+++ b/functions/src/events/scrapeEvents.ts
@@ -171,7 +171,7 @@ const extractAudioFromVideo = async (
         resolve()
       })
       .on("error", err => {
-        console.error("FFmpeg error:", err)
+        functions.logger.error("FFmpeg error:", err)
         reject(err)
       })
       .save(tmpFilePath)
@@ -394,7 +394,10 @@ class HearingScraper extends EventScraper<HearingListItem, Hearing> {
           } as Hearing
         }
       } catch (error) {
-        console.error(`Failed to process audio for hearing ${EventId}:`, error)
+        functions.logger.error(
+          `Failed to process audio for hearing ${EventId}:`,
+          error
+        )
         return {
           id: `hearing-${EventId}`,
           type: "hearing",
@@ -460,7 +463,7 @@ export const scrapeSingleHearing = functions
         hearingId: hearing.id
       }
     } catch (error: any) {
-      console.error(`Failed to scrape hearing ${eventId}:`, error)
+      functions.logger.error(`Failed to scrape hearing ${eventId}:`, error)
       throw new functions.https.HttpsError(
         "internal",
         `Failed to scrape hearing ${eventId}`,
@@ -505,7 +508,7 @@ export const scrapeSingleHearingv2 = onCall(
         hearingId: hearing.id
       }
     } catch (error: any) {
-      console.error(`Failed to scrape hearing ${eventId}:`, error)
+      functions.logger.error(`Failed to scrape hearing ${eventId}:`, error)
       throw new functions.https.HttpsError(
         "internal",
         `Failed to scrape hearing ${eventId}`,


### PR DESCRIPTION
## Summary

We've run into a recent problem with the hearing scraper where we hit our bill spend limit on AssemblyAI, but did not notice because nothing was emitted to Error Reporting. I believe this is happening because we're catching and handling the error instead of letting it percolate to the Firebase Functions error reporting handler - which is why we see some errors correctly reported, but not all.

This will hit us especially hard on our batch scrapers, because we swallow errors with individual resources to avoid crashing the whole job - which means we can miss widespread issues..

This PR is a test of a fix for this (that can only be confirmed in a deployed environment) - by using the firebase functions error logger directly (instead of indirectly via the `console` decorators), it should make it simpler for Google Cloud Error Reporting to detect and report these errors.

This is likely related to https://github.com/codeforboston/maple/issues/2120 - a similar error reporting-related issue we found in our Bill Scraper.

If this works as expected, I'll follow up by instrumenting all of our caught errors in Firebase Functions with the same fix.