### PR TITLE
Fix MCP token page and env functions

### DIFF
--- a/functions/.env.digital-testimony-prod
+++ b/functions/.env.digital-testimony-prod
@@ -1,2 +1,3 @@
 TYPESENSE_API_URL=https://yyd73lsw3h.execute-api.us-east-1.amazonaws.com/search
 FUNCTIONS_API_BASE=https://us-central1-digital-testimony-prod.cloudfunctions.net
+MCP_SERVER_URL=https://maple-mcp-server-652493556525.us-central1.run.app

--- a/pages/dev/token.tsx
+++ b/pages/dev/token.tsx
@@ -13,6 +13,7 @@
 
 import { useAuth } from "components/auth"
 import { createPage } from "components/page"
+import { createGetStaticTranslationProps } from "components/translations"
 import React, { useState, useCallback } from "react"
 
 function TokenPage() {
@@ -145,6 +146,12 @@ function TokenPage() {
 export default createPage({
   Page: TokenPage
 })
+
+export const getStaticProps = createGetStaticTranslationProps([
+  "auth",
+  "common",
+  "footer"
+])
 
 // ── Styles ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Summary

Fixes raw i18n keys (`navigation.bills`, `logInSignUp`, etc.) rendering in the Navbar and Footer on `/dev/token`. The page was missing `getStaticProps`, so next-i18next never loaded the `common`, `auth`, or `footer` namespaces server-side.

Also adds `MCP_SERVER_URL` to `functions/.env.digital-testimony-prod` so the prod `mcpProxy` Firebase Function knows where to find the Cloud Run MCP server (previously it would return 503).

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story. - **N/A**
- [ ] I've made pages responsive and look good on mobile.. - **N/A**
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json`. - **N/A**

# Screenshots

Before
<img width="1110" height="641" alt="image" src="https://github.com/user-attachments/assets/d8b40fdc-9059-41c9-80f8-24a7256ba0ea" />


After
<img width="1110" height="641" alt="image" src="https://github.com/user-attachments/assets/b67c23c6-414d-48cf-9086-9838161c4da7" />


# Known issues

`/dev/token` still has hardcoded English strings in its body (flagged by `i18next/no-literal-string`). This is a dev-only utility page, so this is probably ok.

# Steps to test/reproduce

1. Sign in at the dev or prod MAPLE site
2. Navigate to `/dev/token`
3. Confirm the Navbar and Footer render real text (Bills, Hearings, etc.) instead of raw keys