### PR TITLE
fix org socials

### DIFF
--- a/components/EditProfilePage/PersonalInfoTab.tsx
+++ b/components/EditProfilePage/PersonalInfoTab.tsx
@@ -197,29 +197,15 @@ export function PersonalInfoTab({
                     label={t("socialLinks.instagram")}
                     defaultValue={social?.instagram}
                     className="col-sm-12 col-md-6 mb-1"
-                    iconSrc="./instagram.svg"
+                    iconSrc="/instagram.svg"
                     {...register("instagram")}
                   />
                   <SocialInput
                     label={t("socialLinks.facebook")}
                     defaultValue={social?.fb}
                     className="col-sm-12 col-md-6"
-                    iconSrc="./facebook.svg"
+                    iconSrc="/facebook.svg"
                     {...register("fb")}
-                  />
-                  <SocialInput
-                    label={t("socialLinks.bluesky")}
-                    defaultValue={social?.blueSky}
-                    className="col-sm-12 col-md-6 mb-1"
-                    iconSrc="./bluesky.svg"
-                    {...register("blueSky")}
-                  />
-                  <SocialInput
-                    label={t("socialLinks.mastodon")}
-                    defaultValue={social?.mastodon}
-                    className="col-sm-12 col-md-6 mb-1"
-                    iconSrc="./mastodon.svg"
-                    {...register("mastodon")}
                   />
                 </>
               )}


### PR DESCRIPTION
# Summary

Orgs get additional social links beyond the basic ones regular accounts get

1) additional link icons were missing
2) two additional links (BlueSky, Mastodon) are already included in the basic set -> removed redundant elements

# Screenshots

<img width="1045" height="259" alt="image" src="https://github.com/user-attachments/assets/622c5e70-2043-479e-b6e1-debb6a2bc729" />

# Known issues

none

# Steps to test/reproduce

1. login with a org account
2. got to the Edit Profile page
