### PR TITLE
[Our Team page, Partners tab] remove shoopty whoop

### DIFF
--- a/components/OurTeam/Partners.tsx
+++ b/components/OurTeam/Partners.tsx
@@ -14,7 +14,7 @@ export const LocalizedContent = (props: {
     components={{
       a: (
         <a
-          // href values are overridden by partners.json"
+          // href values are overridden by partners.json
           target="_blank"
           rel="noreferrer"
           className={props.linkClassName}

--- a/components/OurTeam/Partners.tsx
+++ b/components/OurTeam/Partners.tsx
@@ -14,7 +14,7 @@ export const LocalizedContent = (props: {
     components={{
       a: (
         <a
-          href="value-overridden-by-partners-json"
+          // href="value-overridden-by-partners-json"
           target="_blank"
           rel="noreferrer"
           className={props.linkClassName}

--- a/components/OurTeam/Partners.tsx
+++ b/components/OurTeam/Partners.tsx
@@ -14,7 +14,7 @@ export const LocalizedContent = (props: {
     components={{
       a: (
         <a
-          // href="value-overridden-by-partners-json"
+          // href values are overridden by partners.json"
           target="_blank"
           rel="noreferrer"
           className={props.linkClassName}


### PR DESCRIPTION
# Summary

/about/our-team > Partners tab

<img width="1069" height="98" alt="image" src="https://github.com/user-attachments/assets/93f005e4-5da6-4167-b39e-a9b5d694d07e" />

all link href values on this page are being overridden by the shoopty whoop and not navigating the user to the proper destination

<img width="1080" height="150" alt="image" src="https://github.com/user-attachments/assets/ddfc5e80-5a6b-45d7-8aab-cfc85dd5a80e" />

links now functional now with 100% less shoopty whoop


<img width="127" height="128" alt="c085f58dca18ee06cd4575b9f805f900" src="https://github.com/user-attachments/assets/6adf62ea-f54c-4027-8a08-12e2254919c9" />
