### PR TITLE
Finance scrapper

### DIFF
--- a/components/LegislatorProfile/TabComponents/FinanceTab.tsx
+++ b/components/LegislatorProfile/TabComponents/FinanceTab.tsx
@@ -57,7 +57,6 @@ export function FinanceTab({ finance }: { finance?: MembersFinance }) {
     .sort((a, b) => b.value - a.value)
 
   const total = categories.reduce((sum, c) => sum + c.value, 0)
-  const nonContribution = finance.otherReceipts?.nonContribution?.amount ?? 0
   const processingFees = finance.breakdown?.processingFees?.amount ?? 0
 
   const smallDonorTotal =
@@ -270,14 +269,6 @@ export function FinanceTab({ finance }: { finance?: MembersFinance }) {
               : t("finance.source")}
           </p>
         </div>
-      )}
-
-      {nonContribution > 0 && (
-        <p className="text-muted mt-3" style={{ fontSize: 12 }}>
-          {t("finance.otherReceipts", {
-            amount: formatCurrency(nonContribution)
-          })}
-        </p>
       )}
 
       {processingFees > 0 && (

--- a/components/db/membersFinance.ts
+++ b/components/db/membersFinance.ts
@@ -38,10 +38,6 @@ export interface MembersFinanceInKind {
   unitemized: { amount: number }
 }
 
-export interface MembersFinanceOtherReceipts {
-  nonContribution: FinanceBreakdownEntry
-}
-
 export interface MembersFinanceYearData {
   totalRaised: number
   totalSpent: number
@@ -65,7 +61,6 @@ export interface MembersFinance {
   breakdown: MembersFinanceBreakdown
   candidateFunds: MembersFinanceCandidateFunds
   inKind: MembersFinanceInKind
-  otherReceipts: MembersFinanceOtherReceipts
   years: Record<string, MembersFinanceYearData>
 }
 

--- a/functions/src/ocpf/scrapeOcpfFinance.ts
+++ b/functions/src/ocpf/scrapeOcpfFinance.ts
@@ -609,7 +609,7 @@ function accumulateItem(
     case 319: // Payment-processor fee (see breakdown.processingFees doc comment)
       addTo(acc.breakdown.processingFees, yb?.processingFees)
       break
-    // 205 (Bank Interest) and 220 (Aggregated un-itemized) come from reports.txt, not items
+    // 205 (Bank Interest) and 220 (Aggregated un-itemized) totals sourced from reports.txt, not items
     default:
       break
   }

--- a/functions/src/ocpf/scrapeOcpfFinance.ts
+++ b/functions/src/ocpf/scrapeOcpfFinance.ts
@@ -13,7 +13,6 @@ import {
   MembersFinanceBreakdown,
   MembersFinanceCandidateFunds,
   MembersFinanceInKind,
-  MembersFinanceOtherReceipts,
   MembersFinanceYearData
 } from "./types"
 
@@ -84,9 +83,6 @@ interface MemberAccumulator {
     union: MutableBreakdownEntry
     unitemized: { amount: number }
   }
-  otherReceipts: {
-    nonContribution: MutableBreakdownEntry
-  }
   years: Record<
     string,
     {
@@ -150,7 +146,6 @@ function newAccumulator(cpfId: number): MemberAccumulator {
       union: emptyEntry(),
       unitemized: { amount: 0 }
     },
-    otherReceipts: { nonContribution: emptyEntry() },
     years: Object.fromEntries(YEARS.map(y => [y, yearInit()])),
     yearEndCheck: Object.fromEntries(YEARS.map(y => [y, null]))
   }
@@ -304,7 +299,6 @@ export const scrapeOcpfFinance = functions
         breakdown: acc.breakdown as MembersFinanceBreakdown,
         candidateFunds: acc.candidateFunds as MembersFinanceCandidateFunds,
         inKind: acc.inKind as MembersFinanceInKind,
-        otherReceipts: acc.otherReceipts as MembersFinanceOtherReceipts,
         years: Object.fromEntries(
           Object.entries(acc.years).map(([y, yd]) => [
             y,
@@ -600,8 +594,15 @@ function accumulateItem(
     case 203: // Union/Association Contribution
       addTo(acc.breakdown.union, yb?.union)
       break
-    case 204: // Non-contribution receipt
-      addTo(acc.otherReceipts.nonContribution)
+    case 204: // Non-contribution receipt (refunds, misc.) — not real fundraising.
+      // Bank Report Receipts_Total (summed into totalRaised in parseReports)
+      // includes this cash since it did hit the bank, but OCPF's own public
+      // "Receipts" figure nets it out. Subtract here, once identified, to
+      // match that definition. Verified empirically against ocpf.us: for
+      // CPF 16883 (Rausch), totalRaised minus this exact amount ($101.39)
+      // matched the site's displayed 2026 YTD Receipts to the penny.
+      acc.totalRaised -= amount
+      if (acc.years[year]) acc.years[year].totalRaised -= amount
       break
     case 206: // Candidate Loan
     case 331: // Out-of-pocket expense (as loan)

--- a/functions/src/ocpf/scrapeOcpfFinance.ts
+++ b/functions/src/ocpf/scrapeOcpfFinance.ts
@@ -62,6 +62,8 @@ interface MemberAccumulator {
   totalSpent: number
   cashOnHand: number
   cashOnHandEndDateMs: number // End_Date (as ms) of the most recent Bank Report (type 70) seen
+  startBalance: number
+  startBalanceStartDateMs: number // Start_Date (as ms) of the earliest Bank Report (type 70) seen
   depositEndDateMs: number // End_Date (as ms) of the most recent Deposit Report (type 60) seen
   contributorCount: number
   breakdown: {
@@ -129,6 +131,8 @@ function newAccumulator(cpfId: number): MemberAccumulator {
     totalSpent: 0,
     cashOnHand: 0,
     cashOnHandEndDateMs: 0,
+    startBalance: 0,
+    startBalanceStartDateMs: Infinity,
     depositEndDateMs: 0,
     contributorCount: 0,
     breakdown: {
@@ -292,6 +296,7 @@ export const scrapeOcpfFinance = functions
         totalRaised: acc.totalRaised,
         totalSpent: acc.totalSpent,
         cashOnHand: acc.cashOnHand,
+        startBalance: acc.startBalance,
         contributorCount: acc.contributorCount,
         lastUpdated: now,
         bankDataAsOf: Timestamp.fromMillis(acc.cashOnHandEndDateMs),
@@ -341,7 +346,9 @@ const REPORT_COLUMN_ALIASES: Record<string, string[]> = {
   receiptsTotal: ["receipts_total"],
   receiptsUnitemizedTotal: ["receipts_unitemized_total"],
   expendituresTotal: ["expenditures_total"],
+  startBalance: ["start_balance"],
   endBalance: ["end_balance"],
+  startDate: ["start_date"],
   endDate: ["end_date"]
 }
 
@@ -413,6 +420,7 @@ async function parseReports(
     const receiptsUnitemized =
       parseFloat(col(cols, idx.receiptsUnitemizedTotal)) || 0
     const expendituresTotal = parseFloat(col(cols, idx.expendituresTotal)) || 0
+    const startBalance = parseFloat(col(cols, idx.startBalance)) || 0
     const endBalance = parseFloat(col(cols, idx.endBalance)) || 0
 
     let acc = accumulators.get(memberCode)
@@ -478,6 +486,14 @@ async function parseReports(
     if (reportTypeId === 70 && endDateMs > acc.cashOnHandEndDateMs) {
       acc.cashOnHand = endBalance
       acc.cashOnHandEndDateMs = endDateMs
+    }
+    // Start_Balance from the Bank Report with the earliest Start_Date, i.e. cash
+    // on hand at the start of the election cycle.
+    const startDate = col(cols, idx.startDate)
+    const startDateMs = startDate ? new Date(startDate).getTime() : Infinity
+    if (reportTypeId === 70 && startDateMs < acc.startBalanceStartDateMs) {
+      acc.startBalance = startBalance
+      acc.startBalanceStartDateMs = startDateMs
     }
     // Deposit Reports are filed more frequently than Bank Reports, so this
     // date is normally later — tracked to show readers why the Contributions

--- a/functions/src/ocpf/scrapeOcpfFinance.ts
+++ b/functions/src/ocpf/scrapeOcpfFinance.ts
@@ -37,6 +37,18 @@ const YEAR_END_REPORT_TYPE_IDS = new Set([
   113 // Year-End Report (Municipal)
 ])
 
+// Committee lifecycle reports: like Year-End reports, these roll up a date
+// range already covered by periodic Bank Reports (verified empirically —
+// CPF 16576's Dissolution Report exactly matched the sum of two Bank Reports
+// covering the same period, $1,583.64). Kept separate from
+// YEAR_END_REPORT_TYPE_IDS because their date range doesn't align to a
+// calendar year, so they shouldn't feed the yearEndCheck reconciliation.
+const LIFECYCLE_REPORT_TYPE_IDS = new Set([
+  12, // Dissolution Report
+  14, // Transition-Out Report
+  15 // Transition-In Report
+])
+
 // ── Accumulator types ─────────────────────────────────────────────────────────
 
 interface MutableBreakdownEntry {
@@ -415,6 +427,13 @@ async function parseReports(
       if (acc.yearEndCheck[year] === null) {
         acc.yearEndCheck[year] = { receiptsTotal, expendituresTotal }
       }
+      matched++
+      continue
+    }
+
+    if (LIFECYCLE_REPORT_TYPE_IDS.has(reportTypeId)) {
+      // Dissolution/Transition rollup — same double-counting risk as Year-End,
+      // but not tied to a calendar year, so skipped without feeding yearEndCheck.
       matched++
       continue
     }

--- a/functions/src/ocpf/types.ts
+++ b/functions/src/ocpf/types.ts
@@ -79,6 +79,10 @@ export interface MembersFinance {
   totalRaised: number
   totalSpent: number
   cashOnHand: number
+  // Start_Balance of the earliest Bank Report (type 70) in the tracked window,
+  // i.e. cash on hand at the start of the current election cycle.
+  // TODO: Surface this on the Finance tab.
+  startBalance: number
   contributorCount: number // count of type-201 rows (row = one itemized contribution)
   lastUpdated: FirebaseFirestore.Timestamp
   // End_Date of the most recent Bank Report (type 70) — the basis for totalRaised/cashOnHand.

--- a/functions/src/ocpf/types.ts
+++ b/functions/src/ocpf/types.ts
@@ -62,10 +62,6 @@ export interface MembersFinanceInKind {
   unitemized: { amount: number } // type 420
 }
 
-export interface MembersFinanceOtherReceipts {
-  nonContribution: FinanceBreakdownEntry // type 204
-}
-
 export interface MembersFinanceYearData {
   totalRaised: number
   totalSpent: number
@@ -76,6 +72,9 @@ export interface MembersFinanceYearData {
 // Firestore: /generalCourts/{court}/membersFinance/{memberCode}
 export interface MembersFinance {
   ocpfCpfId: number
+  // Net receipts: Bank Report Receipts_Total, minus non-contribution
+  // receipts (type 204 — refunds/misc from Deposit Reports). Matches OCPF's own public
+  // "Receipts" definition.
   totalRaised: number
   totalSpent: number
   cashOnHand: number
@@ -94,6 +93,5 @@ export interface MembersFinance {
   breakdown: MembersFinanceBreakdown
   candidateFunds: MembersFinanceCandidateFunds
   inKind: MembersFinanceInKind
-  otherReceipts: MembersFinanceOtherReceipts
   years: Record<string, MembersFinanceYearData>
 }

--- a/public/locales/en/legislators.json
+++ b/public/locales/en/legislators.json
@@ -20,7 +20,6 @@
     "electionCycleHeading": "{{year}} Election Cycle",
     "noContributions": "No itemized contributions recorded yet.",
     "noData": "Finance data not yet available for this legislator.",
-    "otherReceipts": "Other non-contribution receipts: {{amount}} (refunds and miscellaneous receipts — not included above)",
     "processingFees": "Category amounts above are shown before {{amount}} in payment-processing fees deducted, which is why they total more than \"Total Raised\" above.",
     "source": "Source: MA OCPF · ocpf.us",
     "sourceWithDate": "Source: MA OCPF · ocpf.us\nIncludes contributions through {{date}}",


### PR DESCRIPTION
# Summary

This PR makes improvements to the legislator pages' finance tab.
Key improvements:
- Added election cycle start balance to Firestore, so it's available to display to users. This will reduce confusion about why a legislator's "total spent" can exceed their "total raised".
- Removed non-contribution receipts from total received on finance tab. This matched OCPF's calculations on their summary pages, and will reduce confusion due to the sum of the contributions breakdown differing from the total raised.  
- Added committee lifecycle reports (ex campaign dissolution) to the exclusion list to prevent double-counting with bank reports for Total Raised.


# Checklist

- [Y] On the frontend, I've made my strings translate-able.
- [N/A] If I've added shared components, I've added a storybook story.
- [N/A] I've made pages responsive and look good on mobile.
- [N/A] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

